### PR TITLE
Adds permission denied error message.

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -813,6 +813,10 @@ parse_log (GLog ** logger, char *tail, int n)
    }
 
    if (!(*logger)->piping && (fp = fopen (conf.ifile, "r")) == NULL)
+      if (errno == EACCES) {
+        error_handler (__PRETTY_FUNCTION__, __FILE__, __LINE__,
+                     "Error while opening the log file. Permission denied.");
+      }
       error_handler (__PRETTY_FUNCTION__, __FILE__, __LINE__,
                      "Error while opening the log file. Make sure it exists.");
 


### PR DESCRIPTION
I was trying to open my log file and I kept getting the "Error while opening the log file. Make sure it exists." message. It turns out I was just lacking permissions and needed to run with sudo. The patch adds a more detailed logging message for this scenario.
