### PR TITLE
custom configuration file option

### DIFF
--- a/goaccess.c
+++ b/goaccess.c
@@ -52,7 +52,7 @@
 #include "util.h"
 
 static WINDOW *header_win, *main_win;
-static char short_options[] = "f:e:acr";
+static char short_options[] = "f:e:p:acr";
 
 GConf conf = { 0 };
 
@@ -109,7 +109,7 @@ cmd_help (void)
 {
    printf ("\nGoAccess - %s\n\n", GO_VERSION);
    printf ("Usage: ");
-   printf ("goaccess [ -e IP_ADDRESS][ - a ][ - r][ - c ]< -f log_file >\n\n");
+   printf ("goaccess [-e IP_ADDRESS][-a][-r][-c][-p CONFIGFILE] -f log_file\n\n");
    printf ("The following options can also be supplied to the command:\n\n");
    printf (" -f <argument> - Path to input log file.\n");
    printf (" -c            - Prompt log/date configuration window.\n");
@@ -117,7 +117,8 @@ cmd_help (void)
    printf (" -a            - Enable a List of User-Agents by host.\n");
    printf ("                 For faster parsing, don't enable this flag.\n");
    printf (" -e <argument> - Exclude an IP from being counted under the\n");
-   printf ("                 HOST module. Disabled by default.\n\n");
+   printf ("                 HOST module. Disabled by default.\n");
+   printf (" -p <argument> - Custom configuration file.\n\n");
    printf ("Examples can be found by running `man goaccess`.\n\n");
    printf ("For more details visit: http://goaccess.prosoftcorp.com\n");
    printf ("GoAccess Copyright (C) 2009-2013 GNU GPL'd, by Gerardo Orellana");
@@ -641,6 +642,9 @@ main (int argc, char *argv[])
        case 'f':
           conf.ifile = optarg;
           break;
+       case 'p':
+	      realpath( optarg, conf.iconfigfile );
+          break;
        case 'e':
           conf.ignore_host = optarg;
           break;
@@ -654,7 +658,7 @@ main (int argc, char *argv[])
           conf.skip_resolver = 1;
           break;
        case '?':
-          if (optopt == 'f' || optopt == 'e')
+          if (optopt == 'f' || optopt == 'e' || optopt == 'p')
              fprintf (stderr, "Option -%c requires an argument.\n", optopt);
           else if (isprint (optopt))
              fprintf (stderr, "Unknown option `-%c'.\n", optopt);

--- a/settings.c
+++ b/settings.c
@@ -86,15 +86,19 @@ parse_conf_file ()
    char *val, *c;
    int key = 0;
    FILE *file;
+       
+   if (conf.iconfigfile != NULL){
+      conf_file = conf.iconfigfile;
+   }else{
+      user_home = getenv ("HOME");
+      if (user_home == NULL)
+        user_home = "";
 
-   user_home = getenv ("HOME");
-   if (user_home == NULL)
-      user_home = "";
+  	  path = xmalloc (snprintf (NULL, 0, "%s/.goaccessrc", user_home) + 1);
+      sprintf (path, "%s/.goaccessrc", user_home);
+      conf_file = path;
+   }
 
-   path = xmalloc (snprintf (NULL, 0, "%s/.goaccessrc", user_home) + 1);
-   sprintf (path, "%s/.goaccessrc", user_home);
-
-   conf_file = path;
    file = fopen (conf_file, "r");
 
    if (file == NULL) {

--- a/settings.h
+++ b/settings.h
@@ -49,6 +49,7 @@ typedef struct GConfKeyword_
 typedef struct GConf_
 {
    char *ifile;
+   char iconfigfile[200];
    char *ignore_host;
    char *date_format;
    char *log_format;


### PR DESCRIPTION
If we have multiple access logs with different formats we cannot use just one config.
With a new commandline option we could define a new "goaccessrc" config file.

eg:

```
goaccess -p /home/me/goaccessrc1 -f access_format1.log
goaccess -p /home/me/goaccessrc2 -f access_format2.log
```

this diff is related to [feature request 9](https://github.com/allinurl/goaccess/issues/9).

best,
