### PR TITLE
fix new modules labels on xterminal - unstable branch

### DIFF
--- a/goaccess.c
+++ b/goaccess.c
@@ -302,12 +302,13 @@ allocate_data ()
           break;
        case COUNTRIES:
           ht = ht_countries;
-          dash->module[module].head = CODES_HEAD;
-          dash->module[module].desc = CODES_DESC;
+          dash->module[module].head = COUNT_HEAD;
+          dash->module[module].desc = COUNT_DESC;
+		  break;
        case CONTINENTS:
           ht = ht_continents;
-          dash->module[module].head = CODES_HEAD;
-          dash->module[module].desc = CODES_DESC;
+          dash->module[module].head = CONTI_HEAD;
+          dash->module[module].desc = CONTI_DESC;
           break;
       }
 


### PR DESCRIPTION
just fix title and description lables of new added modules (countries & continents).
todo: need to fix incorrect percentage and incorrect bw values of those modules.

best,
