### PR TITLE
label for unknown continent same as for unknown country

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -397,7 +397,7 @@ process_continent (const char *continentid)
    else if (memcmp (continentid, "AS", 2) == 0)
       process_generic_data (ht_continents, "Asia");
    else
-      process_generic_data (ht_continents, "Unknown");
+      process_generic_data (ht_continents, "Location Unknown");
 }
 #endif
 


### PR DESCRIPTION
When `GeoIP_country_name_by_name()` cannot find country name, `get_geoip_data()` returns **"Location Unknown"** for country name as result.
When same happens for a continent, we should get **"Location Unknown"** too instead of just "unknown".
