### PR TITLE
if we are outputting HTML, it's ok if the stdin is not a tty

### DIFF
--- a/goaccess.c
+++ b/goaccess.c
@@ -896,7 +896,7 @@ main (int argc, char *argv[])
    if (!isatty (STDOUT_FILENO) || conf.output_format != NULL)
       conf.output_html = 1;
    if (conf.ifile != NULL && !isatty (STDIN_FILENO) &&
-       conf.output_format == NULL)
+      !conf.output_html)
       cmd_help ();
    if (conf.ifile == NULL && isatty (STDIN_FILENO) &&
        conf.output_format == NULL)


### PR DESCRIPTION
Running goaccess without a tty allocated can be normal (like via ssh or
logrotate, etc) if goaccess is outputting to a file. This adds a check for
the HTML output type.
