### PR TITLE
Check if `geo_location_data` is not NULL before using it

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -667,13 +667,15 @@ process_unique_data (char *host, char *date, char *agent)
       process_opesys (ht_os, opsys, os_type);
 
 #ifdef HAVE_LIBGEOIP
-    geo_id = GeoIP_id_by_name (geo_location_data, host);
+    if (geo_location_data != NULL) {
+        geo_id = GeoIP_id_by_name (geo_location_data, host);
 
-    sprintf (location, "%s %s", GeoIP_code_by_id (geo_id),
-             get_geoip_data (host));
-    sprintf (continent, "%s",
-             get_continent_name_and_code (GeoIP_continent_by_id (geo_id)));
-    process_geolocation (ht_countries, location, continent);
+        sprintf (location, "%s %s", GeoIP_code_by_id (geo_id),
+                 get_geoip_data (host));
+        sprintf (continent, "%s",
+                 get_continent_name_and_code (GeoIP_continent_by_id (geo_id)));
+        process_geolocation (ht_countries, location, continent);
+    }
 #endif
 
     if ((date = strchr (visitor_key, '|')) != NULL) {


### PR DESCRIPTION
Hello,

I built your software with GeoIP enabled, and it crashed because my GeoIP database was not installed, and [`Geoip_new()`](https://github.com/allinurl/goaccess/blob/master/goaccess.c#L978) returned `NULL`.

I added a condition to skip the processing of the geolocation if the pointer to the geolocation data is `NULL`, and now it works with and without the GeoIP database.
