### PR TITLE
More operating systems

### DIFF
--- a/opesys.c
+++ b/opesys.c
@@ -34,6 +34,12 @@
 
 /* {"search string", "belongs to"} */
 static const char *os[][2] = {
+  {"Googlebot", "Unix-like"},
+  {"Windows Phone 8.1", "Windows"},
+  {"Windows Phone 8.0", "Windows"},
+  {"Xbox One", "Windows"},
+  {"Xbox", "Windows"},
+  {"Windows NT 6.3; ARM", "Windows"},
   {"Windows NT 6.3", "Windows"},
   {"Windows NT 6.2; ARM", "Windows"},
   {"Windows NT 6.2", "Windows"},
@@ -48,6 +54,7 @@ static const char *os[][2] = {
   {"Windows 98", "Windows"},
   {"Windows 95", "Windows"},
   {"Windows CE", "Windows"},
+  {"bingbot", "Windows"},
   {"Android", "Android"},
   {"Debian", "Linux"},
   {"Ubuntu", "Linux"},
@@ -65,17 +72,20 @@ static const char *os[][2] = {
   {"iPhone", "Macintosh"},
   {"iTunes", "Macintosh"},
   {"OS X", "Macintosh"},
+  {"PlayStation", "BSD"},
   {"FreeBSD", "BSD"},
   {"NetBSD", "BSD"},
   {"OpenBSD", "BSD"},
-  {"SunOS", "Others"},
-  {"AmigaOS", "Others"},
+  {"CrOS", "Chrome OS"},
+  {"SunOS", "Unix-like"},
+  {"QNX", "Unix-like"},
+  {"BB10", "Unix-like"},
   {"BlackBerry", "Others"},
-  {"SymbianOS", "Others"},
   {"Sony", "Others"},
-  {"Xbox", "Others"},
+  {"AmigaOS", "Others"},
+  {"SymbianOS", "Others"},
   {"Nokia", "Others"},
-  {"PlayStation", "Others"}
+  {"Nintendo", "Others"}
 };
 
 /* get Android Codename */
@@ -110,6 +120,8 @@ get_real_win (const char *win)
 {
   if (strstr (win, "6.3"))
     return alloc_string ("Windows 8.1");
+  else if (strstr (win, "6.3; ARM"))
+    return alloc_string ("Windows RT");
   else if (strstr (win, "6.2; ARM"))
     return alloc_string ("Windows RT");
   else if (strstr (win, "6.2"))


### PR DESCRIPTION
Added Windows Phone 8 and 8.1 as Windows.

Added Windows RT 8.1 as Windows.

Newer Xbox is based on Windows (older is not but, but hey: Microsoft). Newest Xbox One self-identifies as Windows NT 6.2. Bingbot assumes Windows because Microsoft. Its all Windows over there.

Newer PlayStation is based on BSD.

Added Chrome OS as own OS due to the retain push of these cheap devices.

Added new overall category "Unix-like".

Google is so large that they get their own damned OS. They are like 40 % of the Internet. Added to top because they pretend to be every weird mobile device, TV, and operating system on the planet to identify mobile-optimized sites and the like. Underlaying systems are probably Linux based but proprietary secrets so who knows. (Goobuntu?) Added to new Unix-like group.

Added QNX as Unix-like.

Added BlackBerry 10 (BB10 based on QNX) as Unix-like.
