### PR TITLE
Document installation on pkgsrc based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ please re-download the key.
     # cd /usr/ports/sysutils/goaccess/ && make install clean
     $ pkg_add -r goaccess
 
+### pkgsrc (NetBSD, SmartOS, ...) ###
+
+    # pkgin install goaccess
+
+
 ## Command Line / Config Options ##
 The following options can also be supplied to the command or specified in the
 configuration file:


### PR DESCRIPTION
goaccess is packaged in pkgsrc, which is the default software repository on NetBSD, SmartOS and available for many other operating systems.
