### PR TITLE
Delete unnecessary checks before calls of the function "free".

### DIFF
--- a/src/commons.c
+++ b/src/commons.c
@@ -167,8 +167,7 @@ list_remove_nodes (GSLList * list)
   GSLList *tmp;
   while (list != NULL) {
     tmp = list->next;
-    if (list->data)
-      free (list->data);
+    free (list->data);
     free (list);
     list = tmp;
   }

--- a/src/gdashboard.c
+++ b/src/gdashboard.c
@@ -158,11 +158,9 @@ free_dashboard_data (GDashData item)
   if (item.metrics == NULL)
     return;
 
-  if (item.metrics->data)
-    free (item.metrics->data);
-  if (item.metrics->bw.sbw)
-    free (item.metrics->bw.sbw);
-  if (conf.serve_usecs && item.metrics->avgts.sts)
+  free (item.metrics->data);
+  free (item.metrics->bw.sbw);
+  if (conf.serve_usecs)
     free (item.metrics->avgts.sts);
   free (item.metrics);
 }
@@ -272,14 +270,10 @@ free_holder_data (GHolderItem item)
 {
   if (item.sub_list != NULL)
     delete_sub_list (item.sub_list);
-  if (item.metrics->data != NULL)
-    free (item.metrics->data);
-  if (item.metrics->method != NULL)
-    free (item.metrics->method);
-  if (item.metrics->protocol != NULL)
-    free (item.metrics->protocol);
-  if (item.metrics != NULL)
-    free (item.metrics);
+  free (item.metrics->data);
+  free (item.metrics->method);
+  free (item.metrics->protocol);
+  free (item.metrics);
 }
 
 /* free memory allocated in holder for specific module */
@@ -1129,8 +1123,7 @@ render_find_dialog (WINDOW * main_win, GScroll * gscroll)
     find_t.pattern = xstrdup (query);
     valid = 0;
   }
-  if (query != NULL)
-    free (query);
+  free (query);
   touchwin (main_win);
   close_win (win);
   wrefresh (main_win);

--- a/src/output.c
+++ b/src/output.c
@@ -1329,8 +1329,7 @@ out:
   /* clean stuff up */
   for (i = 0; i < agents->size; ++i)
     free (agents->items[i].agent);
-  if (agents->items)
-    free (agents->items);
+  free (agents->items);
   free (agents);
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -327,10 +327,8 @@ free_raw_data (GRawData * raw_data)
 #ifdef HAVE_LIBTOKYOCABINET
   int i;
   for (i = 0; i < raw_data->size; i++) {
-    if (raw_data->items[i].key != NULL)
-      free (raw_data->items[i].key);
-    if (raw_data->items[i].value != NULL)
-      free (raw_data->items[i].value);
+    free (raw_data->items[i].key);
+    free (raw_data->items[i].value);
   }
 #endif
   free (raw_data->items);
@@ -393,43 +391,24 @@ init_log_item (GLog * logger)
 static void
 free_logger (GLogItem * glog)
 {
-  if (glog->agent != NULL)
-    free (glog->agent);
-  if (glog->browser != NULL)
-    free (glog->browser);
-  if (glog->browser_type != NULL)
-    free (glog->browser_type);
-  if (glog->continent != NULL)
-    free (glog->continent);
-  if (glog->country != NULL)
-    free (glog->country);
-  if (glog->date != NULL)
-    free (glog->date);
-  if (glog->host != NULL)
-    free (glog->host);
-  if (glog->keyphrase != NULL)
-    free (glog->keyphrase);
-  if (glog->method != NULL)
-    free (glog->method);
-  if (glog->os != NULL)
-    free (glog->os);
-  if (glog->os_type != NULL)
-    free (glog->os_type);
-  if (glog->protocol != NULL)
-    free (glog->protocol);
-  if (glog->ref != NULL)
-    free (glog->ref);
-  if (glog->req_key != NULL)
-    free (glog->req_key);
-  if (glog->req != NULL)
-    free (glog->req);
-  if (glog->status != NULL)
-    free (glog->status);
-  if (glog->time != NULL)
-    free (glog->time);
-  if (glog->uniq_key != NULL)
-    free (glog->uniq_key);
-
+  free (glog->agent);
+  free (glog->browser);
+  free (glog->browser_type);
+  free (glog->continent);
+  free (glog->country);
+  free (glog->date);
+  free (glog->host);
+  free (glog->keyphrase);
+  free (glog->method);
+  free (glog->os);
+  free (glog->os_type);
+  free (glog->protocol);
+  free (glog->ref);
+  free (glog->req_key);
+  free (glog->req);
+  free (glog->status);
+  free (glog->time);
+  free (glog->uniq_key);
   free (glog);
 }
 

--- a/src/tcabinet.c
+++ b/src/tcabinet.c
@@ -387,8 +387,7 @@ ht_insert_hit (TCADB * adb, int data_nkey, int uniq_nkey, int root_nkey)
     map->uniq = uniq_nkey;
   }
   tcadbput (adb, &data_nkey, sizeof (int), map, sizeof (GDataMap));
-  if (map)
-    free (map);
+  free (map);
 
   return 0;
 }
@@ -766,8 +765,7 @@ free_key (TCADB * adb, void *key, int ksize, GO_UNUSED void *user_data)
   int sp = 0;
 
   value = tcadbget (adb, key, ksize, &sp);
-  if (value)
-    free (value);
+  free (value);
   free (key);
 }
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -729,8 +729,7 @@ out:
   /* clean stuff up */
   for (i = 0; i < menu->size; ++i)
     free (menu->items[i].name);
-  if (menu->items)
-    free (menu->items);
+  free (menu->items);
   free (menu);
 }
 
@@ -884,8 +883,7 @@ verify_format (GLog * logger, GSpinner * spinner)
   if (conf.log_format) {
     log_format = escape_str (conf.log_format);
     mvwprintw (win, 12, 2, "%.*s", CONF_MENU_W, log_format);
-    if (conf.log_format)
-      free (conf.log_format);
+    free (conf.log_format);
   }
 
   /* set date format from goaccessrc if available */
@@ -894,8 +892,7 @@ verify_format (GLog * logger, GSpinner * spinner)
   if (conf.date_format) {
     date_format = escape_str (conf.date_format);
     mvwprintw (win, 15, 2, "%.*s", CONF_MENU_W, date_format);
-    if (conf.date_format)
-      free (conf.date_format);
+    free (conf.date_format);
   }
 
   /* set time format from goaccessrc if available */
@@ -904,8 +901,7 @@ verify_format (GLog * logger, GSpinner * spinner)
   if (conf.time_format) {
     time_format = escape_str (conf.time_format);
     mvwprintw (win, 18, 2, "%.*s", CONF_MENU_W, time_format);
-    if (conf.time_format)
-      free (conf.time_format);
+    free (conf.time_format);
   }
 
   wrefresh (win);
@@ -923,12 +919,9 @@ verify_format (GLog * logger, GSpinner * spinner)
     case 32:   /* space */
       gmenu_driver (menu, REQ_SEL);
 
-      if (time_format)
-        free (time_format);
-      if (date_format)
-        free (date_format);
-      if (log_format)
-        free (log_format);
+      free (time_format);
+      free (date_format);
+      free (log_format);
 
       for (i = 0; i < n; ++i) {
         if (menu->items[i].checked != 1)
@@ -952,20 +945,16 @@ verify_format (GLog * logger, GSpinner * spinner)
       /* get input string */
       cstm_log = input_string (win, 12, 2, 70, log_format, 0, 0);
       if (cstm_log != NULL && *cstm_log != '\0') {
-        if (log_format)
-          free (log_format);
+        free (log_format);
 
         log_format = alloc_string (cstm_log);
         free (cstm_log);
       }
       /* did not set an input string */
       else {
-        if (cstm_log)
-          free (cstm_log);
-        if (log_format) {
-          free (log_format);
-          log_format = NULL;
-        }
+        free (cstm_log);
+        free (log_format);
+        log_format = NULL;
       }
       break;
     case 100:  /* d */
@@ -976,20 +965,16 @@ verify_format (GLog * logger, GSpinner * spinner)
       /* get input string */
       cstm_date = input_string (win, 15, 2, 14, date_format, 0, 0);
       if (cstm_date != NULL && *cstm_date != '\0') {
-        if (date_format)
-          free (date_format);
+        free (date_format);
 
         date_format = alloc_string (cstm_date);
         free (cstm_date);
       }
       /* did not set an input string */
       else {
-        if (cstm_date)
-          free (cstm_date);
-        if (date_format) {
-          free (date_format);
-          date_format = NULL;
-        }
+        free (cstm_date);
+        free (date_format);
+        date_format = NULL;
       }
       break;
     case 116:  /* t */
@@ -1000,20 +985,16 @@ verify_format (GLog * logger, GSpinner * spinner)
       /* get input string */
       cstm_time = input_string (win, 18, 2, 14, date_format, 0, 0);
       if (cstm_time != NULL && *cstm_time != '\0') {
-        if (time_format)
-          free (time_format);
+        free (time_format);
 
         time_format = alloc_string (cstm_time);
         free (cstm_time);
       }
       /* did not set an input string */
       else {
-        if (cstm_time)
-          free (cstm_time);
-        if (time_format) {
-          free (time_format);
-          time_format = NULL;
-        }
+        free (cstm_time);
+        free (time_format);
+        time_format = NULL;
       }
       break;
     case 274:  /* F10 */


### PR DESCRIPTION
 [The function "free"](http://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer.
Redundant safety checks can be avoided.