### PR TITLE
Drop math library linking flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,5 +82,4 @@ AM_CFLAGS += -Wwrite-strings -Wshadow -Wpointer-arith -Wsign-compare
 AM_CFLAGS += -Wredundant-decls -Wbad-function-cast -Winline -Wcast-align -Wextra
 AM_CFLAGS += -Wdeclaration-after-statement -Wno-missing-field-initializers
 
-goaccess_LDADD = -lm
 dist_man_MANS = goaccess.1


### PR DESCRIPTION
I haven't found math.h #include in sources, probably a cleanup mess from the past?

Also if you want to use libm, please use configure.ac:

```
AC_CHECK_LIB(m, THE_MATH_FUNCTION_GOACCESS_USES_BUT_NOT_SHOWN_IN_GIT_SO_I_DONT_KNOW_YET)
```