### PR TITLE
Master

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,14 @@ if test "$WITH_TC" = "yes"; then
     CFLAGS="$CFLAGS $BZ2_FLAG"
   fi
 
-  CFLAGS="$CFLAGS -ltokyocabinet -lrt -lc"
+  case "$host_os" in
+    *darwin*)
+       CFLAGS="$CFLAGS -ltokyocabinet -lc"
+    ;;
+    *)
+       CFLAGS="$CFLAGS -ltokyocabinet -lrt -lc"
+    ;;
+  esac
 
 # GLib otherwise
 else

--- a/configure.ac
+++ b/configure.ac
@@ -146,14 +146,7 @@ if test "$WITH_TC" = "yes"; then
     CFLAGS="$CFLAGS $BZ2_FLAG"
   fi
 
-  case "$host_os" in
-    *darwin*)
-       CFLAGS="$CFLAGS -ltokyocabinet -lc"
-    ;;
-    *)
-       CFLAGS="$CFLAGS -ltokyocabinet -lrt -lc"
-    ;;
-  esac
+  CFLAGS="$CFLAGS -ltokyocabinet -lrt -lc"
 
 # GLib otherwise
 else

--- a/src/gdashboard.c
+++ b/src/gdashboard.c
@@ -152,6 +152,12 @@ get_data_pos_rows (void)
   return conf.no_column_names ? DASH_DATA_POS - DASH_COL_ROWS : DASH_DATA_POS;
 }
 
+static int
+get_xpos (void)
+{
+  return DASH_INIT_X;
+}
+
 /* Determine which module should be expanded given the
  * current mouse position. */
 int
@@ -704,7 +710,7 @@ render_description (WINDOW * win, GDashModule * data, int *y)
 static void
 render_metrics (GDashModule * data, GDashRender render, int expanded)
 {
-  int x = DASH_INIT_X;
+  int x = get_xpos ();
   GModule module = data->module;
   const GOutput *output = output_lookup (module);
 
@@ -813,7 +819,7 @@ render_cols (WINDOW * win, GDashModule * data, int *y)
 {
   GModule module = data->module;
   const GOutput *output = output_lookup (module);
-  int x = DASH_INIT_X;
+  int x = get_xpos ();
 
   if (data->idx_data == 0 || conf.no_column_names)
     return;


### PR DESCRIPTION
There is a linker error on Mac OS X when configured with
--enable-tcb=btree or --enable-tcb=btree.  

gcc -O2 -DSYSCONFDIR=\"/usr/local/etc\" -Wno-long-long -Wall -W -Wnested-externs -Wformat=2 -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wwrite-strings -Wshadow -Wpointer-arith -Wsign-compare -Wredundant-decls -Wbad-function-cast -Winline -Wcast-align -Wextra -Wdeclaration-after-statement -Wno-missing-field-initializers -I/sw/include -L/sw/lib -pthread -lz -lbz2 -ltokyocabinet -lrt -lc   -o goaccess src/browsers.o src/color.o src/commons.o src/csv.o src/error.o src/gdashboard.o src/gdns.o src/gholder.o src/gmenu.o src/goaccess.o src/gstorage.o src/json.o src/opesys.o src/options.o src/output.o src/parser.o src/sort.o src/settings.o src/ui.o src/util.o src/xmalloc.o src/tcabdb.o src/tcbtdb.o  src/geolocation.o  -ltokyocabinet -lncursesw -lGeoIP -lpthread 
clang: warning: argument unused during compilation: '-pthread'
ld: library not found for -lrt
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [goaccess] Error 1

The library librt only exist on System V based systems and is not
needed  to build on OS X.
