### PR TITLE
Add WebDav HTTP Methods and HTTP Status from RFC 2518 and RFC 3253

### DIFF
--- a/src/commons.h
+++ b/src/commons.h
@@ -125,7 +125,7 @@ typedef enum MODULES
 
 typedef struct GMetrics
 {
-  /* metric id can be used to identified
+  /* metric id can be used to identify
    * a specific data field */
   uint8_t id;
   char *data;

--- a/src/parser.c
+++ b/src/parser.c
@@ -627,6 +627,25 @@ extract_method (const char *token)
       (lookfor = "TRACE", !memcmp (token, lookfor, 5)) ||
       (lookfor = "CONNECT", !memcmp (token, lookfor, 7)) ||
       (lookfor = "PATCH", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "PROPFIND", !memcmp (token, lookfor, 8)) ||
+      (lookfor = "PROPPATCH", !memcmp (token, lookfor, 9)) ||
+      (lookfor = "MKCOL", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "COPY", !memcmp (token, lookfor, 4)) ||
+      (lookfor = "MOVE", !memcmp (token, lookfor, 4)) ||
+      (lookfor = "LOCK", !memcmp (token, lookfor, 4)) ||
+      (lookfor = "UNLOCK", !memcmp (token, lookfor, 6)) ||
+      (lookfor = "VERSION-CONTROL", !memcmp (token, lookfor, 15)) ||
+      (lookfor = "REPORT", !memcmp (token, lookfor, 6)) ||
+      (lookfor = "CHECKOUT", !memcmp (token, lookfor, 8)) ||
+      (lookfor = "CHECKIN", !memcmp (token, lookfor, 7)) ||
+      (lookfor = "UNCHECKOUT", !memcmp (token, lookfor, 10)) ||
+      (lookfor = "MKWORKSPACE", !memcmp (token, lookfor, 11)) ||
+      (lookfor = "UPDATE", !memcmp (token, lookfor, 6)) ||
+      (lookfor = "LABEL", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "MERGE", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "BASELINE-CONTROL", !memcmp (token, lookfor, 16)) ||
+      (lookfor = "MKACTIVITY", !memcmp (token, lookfor, 10)) ||
+      (lookfor = "ORDERPATCH", !memcmp (token, lookfor, 10)) ||
       (lookfor = "options", !memcmp (token, lookfor, 7)) ||
       (lookfor = "get", !memcmp (token, lookfor, 3)) ||
       (lookfor = "head", !memcmp (token, lookfor, 4)) ||
@@ -635,7 +654,26 @@ extract_method (const char *token)
       (lookfor = "delete", !memcmp (token, lookfor, 6)) ||
       (lookfor = "trace", !memcmp (token, lookfor, 5)) ||
       (lookfor = "connect", !memcmp (token, lookfor, 7)) ||
-      (lookfor = "patch", !memcmp (token, lookfor, 5)))
+      (lookfor = "patch", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "propfind", !memcmp (token, lookfor, 8)) ||
+      (lookfor = "propwatch", !memcmp (token, lookfor, 9)) ||
+      (lookfor = "mkcol", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "copy", !memcmp (token, lookfor, 4)) ||
+      (lookfor = "move", !memcmp (token, lookfor, 4)) ||
+      (lookfor = "lock", !memcmp (token, lookfor, 4)) ||
+      (lookfor = "unlock", !memcmp (token, lookfor, 6)) ||
+      (lookfor = "version-control", !memcmp (token, lookfor, 15)) ||
+      (lookfor = "report", !memcmp (token, lookfor, 6)) ||
+      (lookfor = "checkout", !memcmp (token, lookfor, 8)) ||
+      (lookfor = "checkin", !memcmp (token, lookfor, 7)) ||
+      (lookfor = "uncheckout", !memcmp (token, lookfor, 10)) ||
+      (lookfor = "mkworkspace", !memcmp (token, lookfor, 11)) ||
+      (lookfor = "update", !memcmp (token, lookfor, 6)) ||
+      (lookfor = "label", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "merge", !memcmp (token, lookfor, 5)) ||
+      (lookfor = "baseline-control", !memcmp (token, lookfor, 16)) ||
+      (lookfor = "mkactivity", !memcmp (token, lookfor, 10)) ||
+      (lookfor = "orderpatch", !memcmp (token, lookfor, 10)) )
     return lookfor;
   return NULL;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -65,6 +65,8 @@ static const char *codes[][2] = {
   {"204", "204 - No Content: Request did not return any content"},
   {"205", "205 - Reset Content: Server asked the client to reset the document"},
   {"206", "206 - Partial Content: The partial GET has been successful"},
+  {"207", "207 - Multi-Status: WebDAV; RFC 4918"},
+  {"208", "208 - Already Reported: WebDAV; RFC 5842"},
   {"300", "300 - Multiple Choices: Multiple options for the resource"},
   {"301", "301 - Moved Permanently: Resource has permanently moved"},
   {"302", "302 - Moved Temporarily (redirect)"},


### PR DESCRIPTION
I added the missing HTTP methods and HTTP Status fron the HTTP Extension for Webdav (RFC 2518 and RFC 3253)

Please check and  merge, 
Thanks