### PR TITLE
Virtualmin Support Update goaccess.conf

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -60,6 +60,10 @@
 #
 #log-format %v:%^ %h %^[%d:%t %^] "%r" %s %b "%R" "%u"
 #
+# Virtualmin Log Format with Virtual Host
+#
+#log-format %h %^ %v %^[%d:%t %^] "%r" %s %b "%R" "%u"
+#
 # Common Log Format (CLF)
 #
 #log-format %h %^[%d:%t %^] "%r" %s %b


### PR DESCRIPTION
Virtualmin uses a format that is not NCSA Standard.