### PR TITLE
Add a space after [F1]

### DIFF
--- a/src/goaccess.c
+++ b/src/goaccess.c
@@ -277,7 +277,7 @@ render_screens (void)
   draw_header (stdscr, "", "%s", row - 1, 0, col, color_default);
 
   wattron (stdscr, color->attr | COLOR_PAIR (color->pair->idx));
-  mvaddstr (row - 1, 1, "[F1]Help [Enter] Exp. Panel");
+  mvaddstr (row - 1, 1, "[F1] Help [Enter] Exp. Panel");
   mvprintw (row - 1, 30, "%d - %s", chg, asctime (now_tm));
   mvaddstr (row - 1, col - 21, "[Q]uit GoAccess");
   mvprintw (row - 1, col - 5, "%s", GO_VERSION);


### PR DESCRIPTION
`[F1]Help` :arrow_forward: `[F1] Help`
 