### PR TITLE
Allow empty query string

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1024,8 +1024,9 @@ parse_specifier (GLogItem * glog, char **str, const char *p)
     if (glog->qstr)
       return 1;
     tkn = parse_string (&(*str), p[1], 1);
-    if (tkn == NULL || *tkn == '\0')
-      return 1;
+    if (tkn == NULL || *tkn == '\0') {
+      return 0;
+    }
     if ((glog->qstr = decode_url (tkn)) == NULL)
       return 1;
     free (tkn);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1024,9 +1024,8 @@ parse_specifier (GLogItem * glog, char **str, const char *p)
     if (glog->qstr)
       return 1;
     tkn = parse_string (&(*str), p[1], 1);
-    if (tkn == NULL || *tkn == '\0') {
+    if (tkn == NULL || *tkn == '\0')
       return 0;
-    }
     if ((glog->qstr = decode_url (tkn)) == NULL)
       return 1;
     free (tkn);


### PR DESCRIPTION
Hi,

I am trying to parse the following format log by goaccess.

```
# 200	2016-07-08 10:10:10	435959	/fonts/fontawesome-webfont.woff	?v=4.0.3	-
log_format %s\t%d %t\t%D\t%U\t%q
```

But error happened when query string is empty.

```
# .../fonts/fontawesome-webfont.woff(TAB)(TAB)-
```

Please allow empty query string.
