### PR TITLE
browser: classify google cloud clients

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -86,6 +86,7 @@ static const char *browsers[][2] = {
   {"Epiphany", "Others"},
   {"Firebird", "Others"},
   {"Galeon", "Others"},
+  {"google-cloud-sdk", "Others"},
   {"GranParadiso", "Others"},
   {"IBrowse", "Others"},
   {"K-Meleon", "Others"},


### PR DESCRIPTION
For example, gsutil is based on Python but not a crawler.