### PR TITLE
Allow path other than "/" in web socket URL

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -57,7 +57,7 @@ window.GoAccess = window.GoAccess || {
 	},
 
 	setWebSocket: function (wsConn) {
-		var str = /:[0-9]{1,5}$/.test(wsConn.url) ? wsConn.url : String(wsConn.url + ':' + wsConn.port);
+		var str = /^(wss?:\/\/)?[^\/]+:[0-9]{1,5}\//.test(wsConn.url + "/") ? wsConn.url : String(wsConn.url + ':' + wsConn.port);
 		str = !/^wss?:\/\//i.test(str) ? 'ws://' + str : str;
 		var socket = new WebSocket(str);
 		socket.onopen = function (event) {


### PR DESCRIPTION
Before this fix, if one specifed `--ws-url=wss://mydomain:443/wsproxy`, the implementation would change that to `wss://mydomain:443/wsproxy:7890` (obviously wrong). My use case is nginx proxying incoming WebSocket requests to the goaccess process ([nginx instructions](https://www.nginx.com/blog/websocket-nginx/)) - that way I don't need to open up the goaccess port in the firewall, and can use nginx's HTTPS support, and can use HTTP between nginx and goaccess (SSL feature not needed here).

The change makes the regex less strict, in order to allow URL paths like `/wsproxy`, while still detecting correctly whether a port was specified or not.