### PR TITLE
Use bucket name as virtualhost for Amazon S3

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -70,7 +70,7 @@ static const GPreConfLog logs = {
   "\"%x\",\"%h\",%^,%^,\"%m\",\"%U\",\"%s\",%^,\"%b\",\"%D\",%^,\"%R\",\"%u\"", /* Cloud Storage */
   "%dT%t.%^ %^ %h:%^ %^ %T %^ %^ %^ %s %^ %b \"%r\" \"%u\"",    /* AWS Elastic Load Balancing */
   "%^ %^ %^ %v %^: %x.%^ %~%L %h %^/%s %b %m %U",               /* Squid Native */
-  "%^[%d:%t %^] %h %^\"%r\" %s %^ %b %^ %L %^ \"%R\" \"%u\"",   /* Amazon S3 */
+  "%^ %v [%d:%t %^] %h %^\"%r\" %s %^ %b %^ %L %^ \"%R\" \"%u\"", /* Amazon S3 */
 };
 
 static const GPreConfTime times = {


### PR DESCRIPTION
Use bucket name as virtualhost for Amazon S3.

This isn't as valuable as the request's virtualhost, but is still useful when analyzing aggregated logs.

[S3 logs](http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html) unfortunately do not include virtualhost.

I also removed the whitespace padding before the comment to follow the pattern set by the `Cloud Storage` line.