### PR TITLE
Added sanity check for db-path config variable

### DIFF
--- a/src/tcbtdb.c
+++ b/src/tcbtdb.c
@@ -56,7 +56,16 @@ tc_db_set_path (const char *dbname, int module)
   char *path;
   int cx;
 
+  struct stat info;
+
   if (conf.db_path != NULL) {
+    /* sanity check: Is db_path accessible and a directory? */
+    if (stat(conf.db_path, &info) != 0) {
+      FATAL ("Unable to access database path: %s", strerror(errno));
+    } else if (! (info.st_mode & S_IFDIR)) {
+      FATAL ("Database path is not a directory.");
+    }
+
     cx = snprintf (NULL, 0, "%s%dm%s", conf.db_path, module, dbname) + 1;
     path = xmalloc (cx);
     sprintf (path, "%s%dm%s", conf.db_path, module, dbname);


### PR DESCRIPTION
Just a small change, but it took me quite a while to figure out, why my real time html wasn't updated any more. The reason turned out to be a wrong setting for db-path: A file instead of a directory. Goaccess started without complaining, could even read the database, but not update it. So I wrote this little 'never trust in users input'-patch. 