### PR TITLE
alpine doesn't have bash, so convert to sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ EXPOSE 8080
 # Set the entry point to init.sh
 ###########################################
 
-ENTRYPOINT /opt/init.sh
+ENTRYPOINT ["/opt/init.sh"]

--- a/Dockerfile_src/init.sh
+++ b/Dockerfile_src/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Init script
 #


### PR DESCRIPTION
When trying to play with the docker image, I was running into some errors that wouldn't allow me to step into the container.  These seemed to be because the base image is alpine, and alpine does not have bash.  I also updated the Dockerfile to use the array syntax, which from my reading seems to be the better option: https://www.ctl.io/developers/blog/post/dockerfile-entrypoint-vs-cmd/


Below is what I was using, with the added --entrypoint to get past the error out on the init.sh script that was thrown by the ENTRYPOINT not specifying to use sh.
```
# initial clone and setup
git clone https://github.com/if-kyle/goaccess.git
cd goaccess

# build the docker image
docker build -t goaccess .

# jump in
docker run -it --rm --entrypoint=sh goaccess
sh init.sh
```