### PR TITLE
Parse user configuration first when available (fixes #693)

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -129,17 +129,16 @@ get_config_file_path (void)
     return rpath;
   }
 
-  /* otherwise, fallback to global config file, or
-   * attempt to use the user's config file */
-  if (conf.load_global_config) {
-    upath = get_global_config ();
-    rpath = realpath (upath, NULL);
-    if (upath) {
-      free (upath);
-    }
+  /* attempt to use the user's config file */
+  upath = get_home ();
+  rpath = realpath (upath, NULL);
+  if (upath) {
+    free (upath);
   }
-  if (rpath == NULL) {
-    upath = get_home ();
+
+  /* otherwise, fallback to global config file */
+  if (rpath == NULL && conf.load_global_config) {
+    upath = get_global_config ();
     rpath = realpath (upath, NULL);
     if (upath) {
       free (upath);


### PR DESCRIPTION
Probe for user's goaccessrc first, then fallback to system default.