### PR TITLE
Expose default Goaccess port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN ln -sf /proc/1/fd/1 /var/log/docker.log
 # Expose required ports
 #######################
 
-EXPOSE 8080
+EXPOSE 7890
 
 # Set the entry point to init.sh
 ###########################################

--- a/README
+++ b/README
@@ -51,6 +51,11 @@ outputs the data to the X terminal. Features include:
     GoAccess features an on-disk B+Tree storage for large datasets where it is not
     possible to fit everything in memory.
 
+  * Docker support
+    GoAccess comes with a default Docker (https://hub.docker.com/r/allinurl/goaccess/)
+    that will listen for HTTP connections on port 7890. Although, you can still
+    fully configure it, by using Volume mapping and editing goaccess.conf.
+
   * and more... visit https://goaccess.io for more details.
 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ terminal. Features include:
 
 * **Docker support**
   GoAccess comes with a default [**Docker**](https://hub.docker.com/r/allinurl/goaccess/)
-  that will listen for HTTP connections on port 8080. Although, you can still
+  that will listen for HTTP connections on port 7890. Although, you can still
   fully configure it, by using Volume mapping and editing `goaccess.conf`.
 
 ### Nearly all web log formats... ###
@@ -110,7 +110,7 @@ Download, extract and compile GoAccess with:
 
 ### Docker ###
 
-    docker run --restart=always -d -p 80:8080 -v "/home/user/data:/srv/data" allinurl/goaccess
+    docker run --restart=always -d -p 80:7890 -v "/home/user/data:/srv/data" allinurl/goaccess
 
 You can place your `goaccess.conf` file inside your `/home/user/data` directory,
 which will be used by [**Docker**](https://hub.docker.com/r/allinurl/goaccess/)


### PR DESCRIPTION
Move from 8080 to 7890.

This should avoid confusion like in #727. Since no `goaccess.conf` is provided by default, use the default port where goaccess lives on.