### PR TITLE
Fix typos

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1492,7 +1492,7 @@ GoAccess.Tables = {
 
 	togglePagination: function (panel, page, dataItems) {
 		GoAccess.Panels.enablePagination(panel);
-		// Diable pagination next button if last page is reached
+		// Disable pagination next button if last page is reached
 		if (page >= this.getTotalPages(dataItems))
 			GoAccess.Panels.disableNext(panel);
 		if (page <= 1)

--- a/src/error.h
+++ b/src/error.h
@@ -54,7 +54,7 @@
            __TIME__);                                                         \
   fprintf (stderr, "Config file: %s\n", conf.iconfigfile ?: NO_CONFIG_FILE);  \
   fprintf (stderr, "\nFatal error has occurred");                             \
-  fprintf (stderr, "\nError occured at: %s - %s - %d\n", __FILE__,            \
+  fprintf (stderr, "\nError occurred at: %s - %s - %d\n", __FILE__,            \
            __FUNCTION__, __LINE__);                                           \
   fprintf (stderr, fmt, ##__VA_ARGS__);                                       \
   fprintf (stderr, "\n\n");                                                   \

--- a/src/util.c
+++ b/src/util.c
@@ -119,7 +119,7 @@ static const char *codes[][2] = {
   {"521", "521 - CloudFlare - Web server is down"},
   {"522", "522 - CloudFlare - Connection timed out"},
   {"523", "523 - CloudFlare - Origin is unreachable"},
-  {"524", "524 - CloudFlare - A timeout occured"}
+  {"524", "524 - CloudFlare - A timeout occurred"}
 };
 
 /* Return part of a string


### PR DESCRIPTION
lintian:
I: goaccess: spelling-error-in-binary usr/bin/goaccess occured occurred
I: goaccess: spelling-error-in-binary usr/bin/goaccess Diable Disable