### PR TITLE
autoconf: use non-deprecated functions for lssl, lcrypto test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,8 +49,8 @@ AC_ARG_WITH([openssl],AC_HELP_STRING([--with-openssl], [build with OpenSSL suppo
    [openssl="$withval"],[openssl="no"])
 
 if test "$openssl" = 'yes'; then
-  AC_CHECK_LIB([ssl], [SSL_library_init],,[AC_MSG_ERROR([ssl library missing])])
-  AC_CHECK_LIB([crypto], [CRYPTO_num_locks],,[AC_MSG_ERROR([crypto library missing])])
+  AC_CHECK_LIB([ssl], [SSL_CTX_new],,[AC_MSG_ERROR([ssl library missing])])
+  AC_CHECK_LIB([crypto], [CRYPTO_free],,[AC_MSG_ERROR([crypto library missing])])
 fi
 
 # GeoIP


### PR DESCRIPTION
With OpenSSL 1.1, many deprecated functions were removed.  Unfortunately,
the current configure script checks for these functions, causing an error
during compiling.

Change the script to look for non-deprecated functions, which exist
on both 1.0 and 1.1.

This fixes the build on Debian and Arch, and closes #591.

Signed-off-by: Sean Cross <sean@xobs.io>