### PR TITLE
Fix startup websocket race

### DIFF
--- a/src/gwsocket.c
+++ b/src/gwsocket.c
@@ -347,9 +347,6 @@ start_server (void *ptr_data)
 {
   GWSWriter *writer = (GWSWriter *) ptr_data;
 
-  if ((writer->server = ws_init ("0.0.0.0", "7890")) == NULL)
-    return;
-
   ws_set_config_strict (1);
   if (conf.addr)
     ws_set_config_host (conf.addr);
@@ -388,6 +385,11 @@ setup_ws_server (GWSWriter * gwswriter, GWSReader * gwsreader)
 
   /* send WS data thread */
   thread = &gwswriter->thread;
+
+  /* pre-init the websocket server, to ensure the FIFOs are created */
+  if ((gwswriter->server = ws_init ("0.0.0.0", "7890")) == NULL)
+    FATAL ("Failed init websocket");
+
   id = pthread_create (&(*thread), NULL, (void *) &start_server, gwswriter);
   if (id)
     FATAL ("Return code from pthread_create(): %d", id);

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -2829,7 +2829,6 @@ ws_start (WSServer * server)
 #endif
 
   memset (&fdstate, 0, sizeof fdstate);
-  ws_fifo (server);
   ws_socket (&listener);
 
   while (1) {
@@ -2970,6 +2969,8 @@ ws_init (const char *host, const char *port)
   wsconfig.port = port;
   wsconfig.strict = 0;
   wsconfig.use_ssl = 0;
+
+  ws_fifo (server);
 
   return server;
 }


### PR DESCRIPTION
These two patches solved a problem I was experiencing when doing:

    ssh -i [key] core@remote.local docker logs -f [container] | ./goaccess -o report.html -a --log-format=COMBINED --real-time-html

The root cause is that the primary thread runs before mkfifo() is called.  Running goaccess under valgrind or "strace -ff" was usually enough to get it working, but this patch fixes this race condition.