### PR TITLE
js: app: use wss:// when connecting via https

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -81,7 +81,7 @@ window.GoAccess = window.GoAccess || {
 	setWebSocket: function (wsConn) {
 		var host = null, host = wsConn.url ? wsConn.url : window.location.hostname ? window.location.hostname : "localhost";
 		var str = /^(wss?:\/\/)?[^\/]+:[0-9]{1,5}\//.test(host + "/") ? host : String(host + ':' + wsConn.port);
-		str = !/^wss?:\/\//i.test(str) ? 'ws://' + str : str;
+		str = !/^wss?:\/\//i.test(str) ? (window.location.protocol === "https:" ? 'wss://' : 'ws://') + str : str;
 
 		var socket = new WebSocket(str);
 		socket.onopen = function (event) {


### PR DESCRIPTION
This solves a problem I was experiencing on Firefox, where I had to manually specify --ws-url=wss://hostname

It is now inferred that the protocol should be wss:// when connecting via https.