### PR TITLE
[docker] Add tini as minimal init system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN chmod 0644 * \
 ##############################
 
 RUN apk update \
-    && apk add -u supervisor goaccess
+    && apk add -u supervisor goaccess tini
 
 # Cleanup
 #########
@@ -61,4 +61,4 @@ EXPOSE 7890
 # Set the entry point to init.sh
 ###########################################
 
-ENTRYPOINT ["/opt/init.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/opt/init.sh"]


### PR DESCRIPTION
mainly for signal handling, i.e. make `docker stop` graceful (and faster).

See also, https://github.com/krallin/tini
or https://github.com/krallin/tini/issues/8

Thanks for the nice tool!