### PR TITLE
 fix broken `%~` parse specifier

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1444,7 +1444,7 @@ parse_format (GLogItem * logitem, char *str)
       perc++;
       continue;
     }
-    if (*p == '~') {
+    if (*p == '~' && perc == 0) {
       tilde++;
       continue;
     }


### PR DESCRIPTION
the `~h` option to parse XFF headers conflicted with the `%~` option and
made it non-working

I was trying to parse a Squid logfile in native format (see attached log), which uses a variable number of spaces before the field for processing time. With the current goaccess v1.2 release, the `%~` is not working (with v1.1 neither; more I did not check), because the code enters that path for parsing the XFF header (which obviously fails) upon encountering a `~`. This PR should fix the behavior by checking if a `%` has been encountered before, in which case the 'blank eater' should be executed.

Compilation options:
```
./configure --enable-utf8
make
./goaccess -p goacces.conf -o report.html squid_test.txt
```
output:
```
squid_test.txt [0/s]
Parsed 10 linesproducing the following errors:

Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'
Token '' doesn't match specifier '%h'

Format Errors - Verify your log/date/time format
```
goaccess.conf:
```
time-format %s
date-format %s
log-format %x.%^ %~ %^ %h %^/%s %b %m %U %^
config-dialog false
hl-header true
json-pretty-print false
no-color false
no-column-names false
no-csv-summary false
no-progress false
no-tab-scroll false
with-mouse false
agent-list false
with-output-resolver false
http-method yes
http-protocol yes
no-query-string false
no-term-resolver false
444-as-404 false
4xx-to-unique-count false
all-static-files false
double-decode false
ignore-crawlers false
crawlers-only false
ignore-panel REFERRERS
ignore-panel KEYPHRASES
real-os true
static-file .css
static-file .js
static-file .jpg
static-file .png
static-file .gif
static-file .ico
static-file .jpeg
static-file .pdf
static-file .txt
static-file .csv
static-file .zip
static-file .mp3
static-file .mp4
static-file .mpeg
static-file .mpg
static-file .exe
static-file .swf
static-file .woff
static-file .woff2
static-file .xls
static-file .xlsx
static-file .doc
static-file .docx
static-file .ppt
static-file .pptx
static-file .iso
static-file .gz
static-file .rar
static-file .svg
static-file .bmp
static-file .tar
static-file .tgz
static-file .tiff
static-file .tif
static-file .ttf
static-file .flv
```
[squid_test.txt](https://github.com/allinurl/goaccess/files/1101551/squid_test.txt)

