### PR TITLE
Add log-size switch handling: [-S|--log-size]

### DIFF
--- a/src/commons.c
+++ b/src/commons.c
@@ -420,12 +420,17 @@ init_modules (void)
 /* Get the logs size.
  *
  * If log was piped (from stdin), 0 is returned.
- * On success, it adds up all log sizes and its value is returned. */
+ * On success, it adds up all log sizes and its value is returned.
+ * if --log-size was specified, it will be returned explicitly */
 intmax_t
 get_log_sizes (void)
 {
   int i;
   off_t size = 0;
+
+  /* --log-size */
+  if (conf.log_size > 0)
+    return (intmax_t) conf.log_size;
 
   for (i = 0; i < conf.filenames_idx; ++i) {
     if (conf.filenames[i][0] == '-' && conf.filenames[i][1] == '\0')

--- a/src/options.c
+++ b/src/options.c
@@ -53,7 +53,7 @@
 #include "labels.h"
 #include "util.h"
 
-static char short_options[] = "f:e:p:o:l:H:M:"
+static char short_options[] = "f:e:p:o:l:H:M:S:"
 #ifdef HAVE_LIBGEOIP
   "g"
 #endif
@@ -74,6 +74,7 @@ struct option long_opts[] = {
   {"http-method"          , required_argument , 0 , 'M' } ,
   {"http-protocol"        , required_argument , 0 , 'H' } ,
   {"log-file"             , required_argument , 0 , 'f' } ,
+  {"log-size"             , required_argument , 0 , 'S' } ,
   {"no-query-string"      , no_argument       , 0 , 'q' } ,
   {"no-term-resolver"     , no_argument       , 0 , 'r' } ,
   {"output-format"        , required_argument , 0 , 'o' } ,
@@ -161,7 +162,7 @@ cmd_help (void)
   printf ("\nGoAccess - %s\n\n", GO_VERSION);
   printf (
   "Usage: "
-  "goaccess [filename] [ options ... ] [-c][-M][-H][-q][-d][...]\n"
+  "goaccess [filename] [ options ... ] [-c][-M][-H][-S][-q][-d][...]\n"
   "%s:\n\n", INFO_HELP_FOLLOWING_OPTS);
 
   printf (
@@ -215,6 +216,7 @@ cmd_help (void)
   "File Options\n\n"
   "  -                               - The log file to parse is read from stdin.\n"
   "  -f --log-file=<filename>        - Path to input log file.\n"
+  "  -S --log-size=<number>          - Specify the log size, useful when piping in logs.\n"
   "  -l --debug-file=<filename>      - Send all debug messages to the specified\n"
   "                                    file.\n"
   "  -p --config-file=<filename>     - Custom configuration file.\n"
@@ -689,6 +691,13 @@ read_option_args (int argc, char **argv)
     case 'f':
       if (conf.filenames_idx < MAX_FILENAMES)
         conf.filenames[conf.filenames_idx++] = optarg;
+      break;
+    case 'S':
+      if (strchr(optarg, '-')) {
+        printf ("[ERROR] log-size must be a positive integer\n");
+        exit (EXIT_FAILURE);
+      }
+      conf.log_size = (uint64_t)atoll(optarg);
       break;
     case 'p':
       /* ignore it */

--- a/src/settings.h
+++ b/src/settings.h
@@ -167,6 +167,7 @@ typedef struct GConf_
   int real_os;                      /* show real OSs */
   int real_time_html;               /* enable real-time HTML output */
   int skip_term_resolver;           /* no terminal resolver */
+  uint64_t log_size;                /* log size override */
 
   /* Internal flags */
   int bandwidth;                    /* is there bandwidth within the req line */


### PR DESCRIPTION
  This is useful when piping in logs for processing in which the log size can be explicitly set.