### PR TITLE
options.c: Fix conf.filenames duplication problem if logs are via pipe.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -674,6 +674,13 @@ verify_global_config (int argc, char **argv)
 void
 add_dash_filename (void)
 {
+  int i;
+  // pre-scan for '-' and don't add if already exists: github.com/allinurl/goaccess/issues/907
+  for (i = 0; i < conf.filenames_idx; ++i) {
+    if (conf.filenames[i][0] == '-' && conf.filenames[i][1] == '\0')
+      return;
+  }
+
   if (conf.filenames_idx < MAX_FILENAMES && !conf.read_stdin) {
     conf.read_stdin = 1;
     conf.filenames[conf.filenames_idx++] = "-";


### PR DESCRIPTION
  fixes allinurl/goaccess#907