### PR TITLE
Add valid_output_type() to validate the filename given via '-o'

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -739,6 +739,10 @@ read_option_args (int argc, char **argv)
       conf.ignore_qstr = 1;
       break;
     case 'o':
+      if (! valid_output_type (optarg)) {
+        printf ("[ERROR] Invalid filename extension used, must be any of .csv, .json, or .html\n");
+        exit (EXIT_FAILURE);
+      }
       if (conf.output_format_idx < MAX_OUTFORMATS)
         conf.output_formats[conf.output_format_idx++] = optarg;
       break;

--- a/src/util.c
+++ b/src/util.c
@@ -406,6 +406,42 @@ find_output_type (char **filename, const char *ext, int alloc)
   return 1;
 }
 
+/* Validates the '-o' filename extension for any of:
+ * 1) .csv
+ * 2) .json
+ * 3) .html
+ *
+ * Return Value
+ * 1: valid
+ * 0: invalid
+ * -1: non-existent extension
+ */
+int
+valid_output_type (const char *filename) {
+  const char *ext = NULL;
+  size_t sl;
+
+  if ((ext = strrchr (filename, '.')) == NULL)
+    return -1;
+
+  ext++;
+  /* Is extension 3<=len<=4? */
+  sl = strlen(ext);
+  if (sl < 3 || sl > 4)
+    return 0;
+
+  if (strcmp ("html", ext) == 0)
+    return 1;
+
+  if (strcmp ("json", ext) == 0)
+    return 1;
+
+  if (strcmp ("csv", ext) == 0)
+    return 1;
+
+  return 0;
+}
+
 /* Search the environment HOME variable and append GoAccess' config
  * file.
  *

--- a/src/util.h
+++ b/src/util.h
@@ -83,6 +83,7 @@ int invalid_ipaddr (char *str, int *ipvx);
 int ip_in_range (const char *ip);
 int str_inarray (const char *s, const char *arr[], int size);
 int str_to_time (const char *str, const char *fmt, struct tm *tm);
+int valid_output_type (const char *filename);
 off_t file_size (const char *filename);
 uint32_t ip_to_binary (const char *ip);
 void append_str (char **dest, const char *src);


### PR DESCRIPTION
  fixes allinurl/goaccess#901