### PR TITLE
Add ability to store accumulated processing time into DB_GEN_STATS tcb file via '--accumulated-time' switch

### DIFF
--- a/src/goaccess.c
+++ b/src/goaccess.c
@@ -1487,6 +1487,17 @@ main (int argc, char **argv)
 
   /* ignore outputting, process only */
   if (conf.process_and_exit) {
+#ifdef TCB_BTREE
+    /* store accumulated processing time
+     * Note: As we store with time_t second resolution,
+     * if elapsed time == 0, we will bump it to 1.
+     */
+    if (conf.store_accumulated_time) {
+      time_t elapsed = end_proc - start_proc;
+      elapsed = (! elapsed) ? ! elapsed : elapsed;
+      ht_insert_genstats_accumulated_time (elapsed);
+      }
+#endif
   }
   /* stdout */
   else if (conf.output_stdout) {

--- a/src/json.c
+++ b/src/json.c
@@ -524,7 +524,14 @@ poverall_invalid_reqs (GJSON * json, GLog * glog, int sp)
 static void
 poverall_processed_time (GJSON * json, int sp)
 {
-  pskeyu64val (json, OVERALL_GENTIME, end_proc - start_proc, sp, 0);
+  uint64_t elapsed_proc = end_proc - start_proc;
+
+#ifdef TCB_BTREE
+  if (conf.store_accumulated_time)
+    elapsed_proc = (uint64_t) ht_get_genstats ("accumulated_time");
+#endif
+
+  pskeyu64val (json, OVERALL_GENTIME, elapsed_proc, sp, 0);
 }
 
 /* Write to a buffer the total number of unique visitors under the

--- a/src/options.c
+++ b/src/options.c
@@ -142,6 +142,7 @@ struct option long_opts[] = {
   {"geoip-city-data"      , required_argument , 0 ,  0  } ,
 #endif
 #ifdef TCB_BTREE
+  {"accumulated-time"     , no_argument       , 0 ,  0  } ,
   {"cache-lcnum"          , required_argument , 0 ,  0  } ,
   {"cache-ncnum"          , required_argument , 0 ,  0  } ,
   {"compression"          , required_argument , 0 ,  0  } ,
@@ -242,6 +243,9 @@ cmd_help (void)
   "  --444-as-404                    - Treat non-standard status code 444 as 404.\n"
   "  --4xx-to-unique-count           - Add 4xx client errors to the unique visitors\n"
   "                                    count.\n"
+#ifdef TCB_BTREE
+  "  --accumulated-time              - Store accumulated time from parsing day-by-day logs.\n"
+#endif
   "  --all-static-files              - Include static files with a query string.\n"
   "  --crawlers-only                 - Parse and display only crawlers.\n"
   "  --date-spec=<date|hr>           - Date specificity. Possible values: `date`\n"
@@ -499,6 +503,10 @@ parse_long_opt (const char *name, const char *oarg)
   /* 4xx to unique count */
   if (!strcmp ("4xx-to-unique-count", name))
     conf.client_err_to_unique_count = 1;
+
+  /* store accumulated time in tcb */
+  if (!strcmp ("accumulated-time", name))
+    conf.store_accumulated_time = 1;
 
   /* all static files */
   if (!strcmp ("all-static-files", name))

--- a/src/settings.h
+++ b/src/settings.h
@@ -135,6 +135,7 @@ typedef struct GConf_
   const char *ws_url;               /* WebSocket URL */
 
   /* User flags */
+  int store_accumulated_time;       /* store accumulated processing time in tcb */
   int all_static_files;             /* parse all static files */
   int append_method;                /* append method to the req key */
   int append_protocol;              /* append protocol to the req key */

--- a/src/tcabdb.c
+++ b/src/tcabdb.c
@@ -1219,6 +1219,21 @@ ht_replace_genstats (const char *key, int value)
   return ins_si32 (hash, key, value);
 }
 
+/* Increases the general stats counter accumulated_time.
+ *
+ * On error,  0 is returned
+ * On success 1 is returned */
+int
+ht_insert_genstats_accumulated_time (time_t elapsed)
+{
+  void *hash = ht_general_stats;
+
+  if (!hash)
+    return 0;
+
+  return inc_si32(hash, "accumulated_time", (int)elapsed) != -1;
+}
+
 /* Increases a general stats counter uint64_t from a string key.
  *
  * On error, -1 is returned.

--- a/src/tcabdb.h
+++ b/src/tcabdb.h
@@ -174,6 +174,7 @@ int ht_insert_agent (GModule module, int key, int value);
 int ht_insert_bw (GModule module, int key, uint64_t inc);
 int ht_insert_cumts (GModule module, int key, uint64_t inc);
 int ht_insert_datamap (GModule module, int key, const char *value);
+int ht_insert_genstats_accumulated_time (time_t elapsed);
 int ht_insert_genstats_bw (const char *key, uint64_t inc);
 int ht_insert_genstats (const char *key, int inc);
 int ht_insert_hits (GModule module, int key, int inc);


### PR DESCRIPTION
  This was done to facilitate the processing flow of adding daily logs to the stored tcb files
    and then running the daily report against it.  This problem was that 'Init. Proc. Time' only
    showed the processing time for the current processed log, however we need it to show the
    accumulated time over the entire monthly report processing span.
