### PR TITLE
Add systemd service, timer files and runner

### DIFF
--- a/examples/goaccess.service
+++ b/examples/goaccess.service
@@ -1,0 +1,34 @@
+# /etc/systemd/system/goaccess.service
+
+[Unit]
+Description=Goaccess timed log scan
+After=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/tmp
+ExecStartPre=/bin/mkdir -p /var/lib/goaccess
+ExecStart=/usr/sbin/goaccess_runner
+
+# Hardening
+
+NoNewPrivileges=true
+PermissionsStartOnly=true
+# CapabilityBoundingSet=
+PrivateTmp=true
+ProtectHome=read-only
+ProtectSystem=full
+SystemCallFilter=~@clock #@cpu-emulation @debug @keyring @memlock @module @mount @obsolete @privileged @reboot @resources @setuid @swap @raw-io
+# Required: @network-io @ipc
+
+ReadOnlyDirectories=/
+ReadWriteDirectories=/proc/self
+ReadWriteDirectories=-/var/lib/goaccess
+ReadWriteDirectories=-/var/www
+
+PrivateDevices=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+
+StandardOutput=syslog+console
+StandardError=syslog+console

--- a/examples/goaccess.timer
+++ b/examples/goaccess.timer
@@ -1,0 +1,12 @@
+# /etc/systemd/system/goaccess.timer
+
+[Unit]
+Description=Goaccess timed log scan
+After=network-online.target
+
+[Install]
+WantedBy=timers.target
+
+[Timer]
+RandomizedDelaySec=2s
+OnUnitActiveSec=60s

--- a/examples/goaccess_runner.sh
+++ b/examples/goaccess_runner.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Discover log files from various webservers.
+# Create persistent database, process logs.
+
+GOACCESS=/usr/bin/goaccess
+
+# no trailing slash
+DBPATH=/var/lib/goaccess
+HTMLPATH=/var/www/html/goaccess
+
+log() {
+  if [ -f /usr/bin/systemd-cat ]; then
+    echo "goaccess_runner $1" | /usr/bin/systemd-cat
+  else
+    /usr/bin/logger "goaccess_runner $1"
+  fi
+}
+
+for wsdir in /var/log/nginx /var/log/apache2 ; do
+
+  if [ ! -d $wsdir ]; then
+    continue
+  fi
+
+  for logfname in $wsdir/*.log; do
+    sitename=$(basename ${logfname%.log})
+    [[ $sitename == error ]] && continue
+    [[ $sitename == netdata ]] && continue
+
+    dbdir="$DBPATH/$sitename"
+    if [ ! -d $dbdir ]; then
+      log "initializing $HTMLPATH/$sitename.html"
+      mkdir -p $dbdir
+      # e.g. /var/log/nginx/foo.org.log.6.gz
+      if compgen -G "$logfname.*.gz" > /dev/null; then
+        for zfn in $logfname.*.gz; do
+          log "parsing $zfn"
+          zcat $zfn | $GOACCESS \
+            --keep-db-files --load-from-disk \
+            --db-path=$dbdir \
+            -f - \
+            -o $HTMLPATH/$sitename.html \
+            --log-format=COMMON || true
+        done
+      fi
+    fi
+
+    log "updating $HTMLPATH/$sitename.html"
+    $GOACCESS \
+      --keep-db-files --load-from-disk \
+      --db-path=$dbdir \
+      -f $logfname \
+      -o $HTMLPATH/$sitename.html \
+      --log-format=COMMON || true
+
+  done  # logfname
+done  # wsdir


### PR DESCRIPTION
Add a script to scan logfile locations for common HTTP servers.
Add systemd service and timer files for timed runs.
The sandbox can be improved in future by restricting network I/O and capabilities.