### PR TITLE
Added "Tiny Tiny RSS" to browsers.c file.

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -297,6 +297,7 @@ static const char *browsers[][2] = {
   {"newsbeuter", "Feeds"},
   {"Wrangler", "Feeds"},
   {"Fever", "Feeds"},
+  {"Tiny Tiny RSS", "Feeds"},
 
   {"Pingdom.com", "Uptime"},
   {"UptimeRobot", "Uptime"},


### PR DESCRIPTION
Hi. I've added "Tiny Tiny RSS" to the "Feeds" category in `browsers.c`. [Tiny Tiny RSS](https://tt-rss.org/) is a self-hosted and web-based RSS feed reader with a user-agent string like: `Tiny Tiny RSS/17.4 (http://tt-rss.org/)`. I hope, this is helpful and I can contribute to your project with this pull request.

## Additional:
I compiled this, but in the terminal ui interface, only `Tiny Tiny` instead of `Tiny Tiny RSS` is displayed within the "Browsers" section (see attachment). I don't know if this is a bug or expected behavior. Maybe the string is cut because of spaces between the words?

![ctj69vqe](https://user-images.githubusercontent.com/7452174/32190853-70401174-bdaf-11e7-9bba-54d177dc3df6.png)

To test this, I've compiled with `{"TinyTinyRSS", "Feeds"}` (without spaces) and a test log which contains such a user-agent: `TinyTinyRSS/17.4 (http://tt-rss.org/)`. Then `TinyTinyRSS/17.4` is displayed.