### PR TITLE
parser.c: fix warning: comparison of array 'hour' equal to a null pointer is always false

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2353,7 +2353,7 @@ gen_visit_time_key (GKeyData * kdata, GLogItem * logitem)
       0)
     return 1;
 
-  if (hour == '\0')
+  if (*hour == '\0')
     return 1;
 
   if ((hmark = strchr (hour, ':')))


### PR DESCRIPTION
  https://travis-ci.org/allinurl/goaccess/jobs/305616842#L2488-L2491

```
  src/parser.c:2356:7: warning: comparison of array 'hour' equal to a null pointer
        is always false [-Wtautological-pointer-compare]
    if (hour == '\0')
        ^~~~    ~~~~
  1 warning generated.
```
