### PR TITLE
settings.c: fix warning: expression which evaluates to zero treated as a null pointer constant of type 'char *'

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -235,7 +235,7 @@ append_to_argv (int *argc, char ***argv, char *val)
 {
   char **_argv = xrealloc (*argv, (*argc + 2) * sizeof (*_argv));
   _argv[*argc] = val;
-  _argv[*argc + 1] = '\0';
+  _argv[*argc + 1] = (char *)'\0';
   (*argc)++;
   *argv = _argv;
 }


### PR DESCRIPTION
  https://travis-ci.org/allinurl/goaccess/jobs/305616842#L2496-L2499

```
  src/settings.c:238:22: warning: expression which evaluates to zero treated as a
        null pointer constant of type 'char *' [-Wnon-literal-null-conversion]
    _argv[*argc + 1] = '\0';
                       ^~~~
  1 warning generated.
```
