### PR TITLE
Add SSL support for docker goaccess build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ COPY . /goaccess
 WORKDIR /goaccess
 
 ARG build_deps="build-base ncurses-dev autoconf automake git gettext-dev"
-ARG runtime_deps="tini ncurses libintl gettext "
+ARG runtime_deps="tini ncurses libintl gettext openssl-dev"
 
 RUN apk update && \
     apk add -u $runtime_deps $build_deps && \
     autoreconf -fiv && \
-    ./configure --enable-utf8 && \
+    ./configure --enable-utf8 --with-openssl && \
     make && \
     make install && \
     apk del $build_deps && \


### PR DESCRIPTION
Addresses: [Goaccess docker ssl-cert unrecognized #1030](https://github.com/allinurl/goaccess/issues/1030)

I cloned the goaccess repo, changed the docker file as follows:
* apk added [openssl-dev](https://pkgs.alpinelinux.org/package/v3.3/main/x86/openssl-dev) similar to [libssl-dev](https://packages.debian.org/jessie/libssl-dev) (couldn't find libssl-dev for `apk`)
* added `--with-openssl` to the goaccess build configuration (in Dockerfile)

I built and tested the resulting image with valid certificates and a socket connection with `wss://` worked.

@allinurl  let me know what you think. If approved, I'll update the Readme file and docs as well.