### PR TITLE
uniq (default) dbpath for each process

### DIFF
--- a/goaccess.1
+++ b/goaccess.1
@@ -687,8 +687,8 @@ Only if configured with --enable-tcb=btree
 .TP
 \fB\-\-db-path=<dir>
 Path where the on-disk database files are stored. The default value is the
-.I /tmp
-directory.
+.I /tmp/goaccess<PID>
+directory (created on-demand).
 
 Only if configured with --enable-tcb=btree
 .TP

--- a/src/tcabdb.c
+++ b/src/tcabdb.c
@@ -282,6 +282,11 @@ free_storage (void)
     free_metrics (module_list[idx]);
   }
   free (tc_storage);
+
+#ifdef TCB_BTREE
+  tc_db_rmdir();
+#endif
+
 }
 
 static uint32_t

--- a/src/tcbtdb.h
+++ b/src/tcbtdb.h
@@ -46,7 +46,8 @@
 #define TC_LMEMB 128
 #define TC_NMEMB 256
 #define TC_BNUM  32749
-#define TC_DBPATH "/tmp/"
+#define TC_DBPATH "/tmp/goaccess"
+#define TC_DBPMODE 0755
 #define TC_ZLIB 1
 #define TC_BZ2  2
 
@@ -78,6 +79,7 @@
 TCBDB *tc_bdb_create (char *dbpath);
 
 char *tc_db_set_path (const char *dbname, int module);
+void tc_db_rmdir(void);
 int tc_bdb_close (void *db, char *dbname);
 void tc_db_get_params (char *params, const char *path);
 


### PR DESCRIPTION
When we start multiple (btree enabled) goaccess processes, each of them gets a uniq folder for its database files. (Only if no db-path is specified, neither in the config file nor with the --db-path CLI argument). This makes parallel processing possible in an easy way. The extra folder is removed at the housekeeping.