### PR TITLE
added configure arguments to --version output

### DIFF
--- a/src/commons.c
+++ b/src/commons.c
@@ -140,6 +140,39 @@ display_version (void)
   fprintf (stdout, "GoAccess - %s.\n", GO_VERSION);
   fprintf (stdout, "%s: http://goaccess.io\n", INFO_MORE_INFO);
   fprintf (stdout, "Copyright (C) 2009-2016 by Gerardo Orellana\n");
+  fprintf (stdout, "\nBuild configure arguments:\n");
+#ifdef DEBUG
+  fprintf (stdout, "  --enable-debug\n");
+#endif
+#ifdef HAVE_NCURSESW_NCURSES_H
+  fprintf (stdout, "  --enable-utf8\n");
+#endif
+#ifdef HAVE_LIBGEOIP
+  fprintf (stdout, "  --enable-geoip=legacy\n");
+#endif
+#ifdef HAVE_LIBMAXMINDDB
+  fprintf (stdout, "  --enable-geoip=mmdb\n");
+#endif
+#ifdef TCB_MEMHASH
+  fprintf (stdout, "  --enable-tcb=memhash\n");
+#endif
+#ifdef TCB_BTREE
+  fprintf (stdout, "  --enable-tcb=btree\n");
+#endif
+#if defined(TCB_MEMHASH) || defined(TCB_BTREE)
+#ifndef HAVE_ZLIB
+  fprintf (stdout, "  --disable-zlib\n");
+#endif
+#ifndef HAVE_BZ2
+  fprintf (stdout, "  --disable-bzip\n");
+#endif
+#endif
+#ifdef WITH_GETLINE
+  fprintf (stdout, "  --with-getline\n");
+#endif
+#ifdef HAVE_LIBSSL
+  fprintf (stdout, "  --with-openssl\n");
+#endif
 }
 
 /* Get the enumerated value given a string.


### PR DESCRIPTION
I added configure arguments to the `--version` output. As suggested in #940 

If anything is wrong or you would like this implemented in different way, I would be happy to change anything. 😃

I thought this had been referenced in another issue also but I can't find it.