### PR TITLE
added first/last buttons to html report

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -708,14 +708,42 @@ GoAccess.Panels = {
 			$pagination.parentNode.classList.add('disabled');
 	},
 
+	enableFirst: function (panel) {
+		var $pagination = $('#panel-' + panel + ' .pagination a.panel-first');
+		if ($pagination)
+			$pagination.parentNode.classList.remove('disabled');
+	},
+
+	disableFirst: function (panel) {
+		var $pagination = $('#panel-' + panel + ' .pagination a.panel-first');
+		if ($pagination)
+			$pagination.parentNode.classList.add('disabled');
+	},
+
+	enableLast: function (panel) {
+		var $pagination = $('#panel-' + panel + ' .pagination a.panel-last');
+		if ($pagination)
+			$pagination.parentNode.classList.remove('disabled');
+	},
+
+	disableLast: function (panel) {
+		var $pagination = $('#panel-' + panel + ' .pagination a.panel-last');
+		if ($pagination)
+			$pagination.parentNode.classList.add('disabled');
+	},
+
 	enablePagination: function (panel) {
 		this.enablePrev(panel);
 		this.enableNext(panel);
+		this.enableFirst(panel);
+		this.enableLast(panel);
 	},
 
 	disablePagination: function (panel) {
 		this.disablePrev(panel);
 		this.disableNext(panel);
+		this.disableFirst(panel);
+		this.disableLast(panel);
 	},
 
 	hasSubItems: function (ui, data) {
@@ -1148,6 +1176,20 @@ GoAccess.Tables = {
 			}.bind(this);
 		}.bind(this));
 
+		$$('.panel-first', function (item) {
+			item.onclick = function (e) {
+				var panel = e.currentTarget.getAttribute('data-panel');
+				this.renderTable(panel, "FIRST_PAGE");
+			}.bind(this);
+		}.bind(this));
+
+		$$('.panel-last', function (item) {
+			item.onclick = function (e) {
+				var panel = e.currentTarget.getAttribute('data-panel');
+				this.renderTable(panel, "LAST_PAGE");
+			}.bind(this);
+		}.bind(this));
+
 		$$('.expandable>td', function (item) {
 			item.onclick = function (e) {
 				if (!window.getSelection().toString())
@@ -1498,15 +1540,26 @@ GoAccess.Tables = {
 	togglePagination: function (panel, page, dataItems) {
 		GoAccess.Panels.enablePagination(panel);
 		// Disable pagination next button if last page is reached
-		if (page >= this.getTotalPages(dataItems))
+		if (page >= this.getTotalPages(dataItems)) {
 			GoAccess.Panels.disableNext(panel);
-		if (page <= 1)
+			GoAccess.Panels.disableLast(panel);
+		}
+		if (page <= 1) {
 			GoAccess.Panels.disablePrev(panel);
+			GoAccess.Panels.disableFirst(panel);
+		}
 	},
 
 	renderTable: function (panel, page) {
 		var dataItems = GoAccess.getPanelData(panel).data;
 		var ui = GoAccess.getPanelUI(panel);
+
+		if (page === "LAST_PAGE") {
+			page = this.getTotalPages(dataItems);
+		}
+		else if (page === "FIRST_PAGE") {
+			page = 1;
+		}
 
 		this.togglePagination(panel, page, dataItems);
 		// Render data rows

--- a/resources/tpls.html
+++ b/resources/tpls.html
@@ -149,12 +149,22 @@
 
 			<ul class="pagination pagination-sm pull-left">
 				<li class="disabled">
+					<a class="panel-first" href="javascript:void(0);" aria-label="{{labels.first}}" data-panel="{{id}}" title="{{labels.first}}">
+						<i class="fa fa-chevron-left"></i>
+					</a>
+				</li>
+				<li class="disabled">
 					<a class="panel-prev" href="javascript:void(0);" aria-label="{{labels.previous}}" data-panel="{{id}}" title="{{labels.previous}}">
 						<i class="fa fa-chevron-left"></i>
 					</a>
 				</li>
 				<li>
 					<a class="panel-next" href="javascript:void(0);" aria-label="{{labels.next}}" data-panel="{{id}}" title="{{labels.next}}">
+						<i class="fa fa-chevron-right"></i>
+					</a>
+				</li>
+				<li>
+					<a class="panel-last" href="javascript:void(0);" aria-label="{{labels.last}}" data-panel="{{id}}" title="{{labels.last}}">
 						<i class="fa fa-chevron-right"></i>
 					</a>
 				</li>

--- a/src/labels.h
+++ b/src/labels.h
@@ -336,6 +336,10 @@
   N_("Previous")
 #define HTML_REPORT_PANEL_NEXT         \
   N_("Next")
+#define HTML_REPORT_PANEL_FIRST        \
+  N_("First")
+#define HTML_REPORT_PANEL_LAST         \
+  N_("Last")
 #define HTML_REPORT_PANEL_CHART_OPTS   \
   N_("Chart Options")
 #define HTML_REPORT_PANEL_CHART        \

--- a/src/output.c
+++ b/src/output.c
@@ -1130,6 +1130,8 @@ print_json_i18n_def (FILE * fp)
     {"panel_opts"     , HTML_REPORT_PANEL_PANEL_OPTS}   ,
     {"previous"       , HTML_REPORT_PANEL_PREVIOUS}     ,
     {"next"           , HTML_REPORT_PANEL_NEXT}         ,
+    {"first"          , HTML_REPORT_PANEL_FIRST}        ,
+    {"last"           , HTML_REPORT_PANEL_LAST}         ,
     {"chart_opts"     , HTML_REPORT_PANEL_CHART_OPTS}   ,
     {"chart"          , HTML_REPORT_PANEL_CHART}        ,
     {"type"           , HTML_REPORT_PANEL_TYPE}         ,


### PR DESCRIPTION
I added `First` and `Last` buttons to the html report. As suggested in #902 

This isn't ready to merge yet because it looks like you've created a min version of Font Awesome that only has the icons needed for the report. How did you make this? Right now the `First` and `Last` buttons are using the same icons as `Previous` and `Next`. Is there a way to add icons for `<<` and `>>`?

Also the double chevrons to match the chevrons for `Previous` and `Next` are part of the pro Font Awesome. So it might be better to use `fa-angle-left` and `fa-angle-double-left` so they match.

