### PR TITLE
added missing call to free()

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1069,6 +1069,7 @@ parse_specifier (GLogItem * logitem, char **str, const char *p, const char *end)
       free (tkn);
       return 1;
     }
+    free (tkn);
     break;
     /* date/time as decimal, i.e., timestamps, ms/us  */
   case 'x':


### PR DESCRIPTION
Sorry I missed this. After the call to `set_time` the token can be freed.