### PR TITLE
Make regular expressions POSIX compatible

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ CLEANFILES =                          \
 # Tpls
 tpls.h: bin2c$(EXEEXT) resources/tpls.html
 if HAS_SEDTR
-	cat resources/tpls.html | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/tpls.html.tmp
+	cat resources/tpls.html | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/tpls.html.tmp
 	./bin2c resources/tpls.html.tmp src/tpls.h tpls
 else
 	./bin2c resources/tpls.html src/tpls.h tpls
@@ -54,7 +54,7 @@ endif
 # Bootstrap
 bootstrapcss.h: bin2c$(EXEEXT) resources/css/bootstrap.min.css
 if HAS_SEDTR
-	cat resources/css/bootstrap.min.css | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/bootstrap.min.css.tmp
+	cat resources/css/bootstrap.min.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/bootstrap.min.css.tmp
 	./bin2c resources/css/bootstrap.min.css.tmp src/bootstrapcss.h bootstrap_css
 else
 	./bin2c resources/css/bootstrap.min.css src/bootstrapcss.h bootstrap_css
@@ -62,7 +62,7 @@ endif
 # Font Awesome
 facss.h: bin2c$(EXEEXT) resources/css/fa.min.css
 if HAS_SEDTR
-	cat resources/css/fa.min.css | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/fa.min.css.tmp
+	cat resources/css/fa.min.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/fa.min.css.tmp
 	./bin2c resources/css/fa.min.css.tmp src/facss.h fa_css
 else
 	./bin2c resources/css/fa.min.css src/facss.h fa_css
@@ -70,7 +70,7 @@ endif
 # App.css
 appcss.h: bin2c$(EXEEXT) resources/css/app.css
 if HAS_SEDTR
-	cat resources/css/app.css | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/app.css.tmp
+	cat resources/css/app.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/app.css.tmp
 	./bin2c resources/css/app.css.tmp src/appcss.h app_css
 else
 	./bin2c resources/css/app.css src/appcss.h app_css
@@ -78,7 +78,7 @@ endif
 # D3.js
 d3js.h: bin2c$(EXEEXT) resources/js/d3.v3.min.js
 if HAS_SEDTR
-	cat resources/js/d3.v3.min.js | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/d3.v3.min.js.tmp
+	cat resources/js/d3.v3.min.js | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/d3.v3.min.js.tmp
 	./bin2c resources/js/d3.v3.min.js.tmp src/d3js.h d3_js
 else
 	./bin2c resources/js/d3.v3.min.js src/d3js.h d3_js
@@ -86,7 +86,7 @@ endif
 # Hogan.js
 hoganjs.h: bin2c$(EXEEXT) resources/js/hogan.min.js
 if HAS_SEDTR
-	cat resources/js/hogan.min.js | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/hogan.min.js.tmp
+	cat resources/js/hogan.min.js | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/hogan.min.js.tmp
 	./bin2c resources/js/hogan.min.js.tmp src/hoganjs.h hogan_js
 else
 	./bin2c resources/js/hogan.min.js src/hoganjs.h hogan_js
@@ -94,7 +94,7 @@ endif
 # Charts.js
 chartsjs.h: bin2c$(EXEEXT) resources/js/charts.js
 if HAS_SEDTR
-	cat resources/js/charts.js | sed -E "s@(,|;)[ \t]*?//..*@\1@g" | sed -E "s@^[ \t]*//..*@@g" | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/charts.js.tmp
+	cat resources/js/charts.js | sed -E "s@(,|;)[[:space:]]*//..*@\1@g" | sed -E "s@^[[:space:]]*//..*@@g" | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/charts.js.tmp
 	./bin2c resources/js/charts.js.tmp src/chartsjs.h charts_js
 else
 	./bin2c resources/js/charts.js src/chartsjs.h charts_js
@@ -102,7 +102,7 @@ endif
 # App.js
 appjs.h: bin2c$(EXEEXT) resources/js/app.js
 if HAS_SEDTR
-	cat resources/js/app.js | sed -E "s@(,|;)[ \t]*?//..*@\1@g" | sed -E "s@^[ \t]*//..*@@g" | sed "s/^[ \t]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/app.js.tmp
+	cat resources/js/app.js | sed -E "s@(,|;)[[:space:]]*//..*@\1@g" | sed -E "s@^[[:space:]]*//..*@@g" | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/app.js.tmp
 	./bin2c resources/js/app.js.tmp src/appjs.h app_js
 else
 	./bin2c resources/js/app.js src/appjs.h app_js


### PR DESCRIPTION
This is a follow up to the comments on 4b8346e

The default `sed` on mac does not support the `*?` non-greedy operator. Which is why `resources/js/charts.js.tmp` and `resources/js/app.js.tmp` were empty and I was getting the error: `RE error: repetition-operator operand invalid` So I removed the non-greedy operator. I don't think it's needed in this context.

I also noticed that the files produced by the default sed on mac were not the same as files produced by GNU sed. I replaced `[ \t]` with `[[:space:]]` and now files produced by default mac sed and GNU sed are identical.