### PR TITLE
Unset referrer header

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -225,11 +225,12 @@ print_html_header (FILE * fp)
   "<!DOCTYPE html>"
   "<html lang='%s'>"
   "<head>"
-  "<meta charset='UTF-8' />"
+  "<meta charset='UTF-8'>"
+  "<meta name='referrer' content='no-referrer'>"
   "<meta http-equiv='X-UA-Compatible' content='IE=edge'>"
   "<meta name='google' content='notranslate'>"
   "<meta name='viewport' content='width=device-width, initial-scale=1'>"
-  "<meta name='robots' content='noindex, nofollow' />", _(DOC_LANG));
+  "<meta name='robots' content='noindex, nofollow'>", _(DOC_LANG));
 
   print_html_title (fp);
 


### PR DESCRIPTION
Server statistics is assumed to be a private page, so don’t send the HTTP Referer (sic) request header with any external links to keep information about the existence of the page from leaking.
https://www.w3.org/TR/referrer-policy/#referrer-policy-no-referrer
https://www.ctrl.blog/entry/private-bts-referrer-header