### PR TITLE
Add missing include for xstrdup. Fixes #1168

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -52,6 +52,7 @@
 #include "error.h"
 #include "labels.h"
 #include "util.h"
+#include "xmalloc.h"
 
 static char short_options[] = "f:e:p:o:l:H:M:S:"
 #ifdef HAVE_LIBGEOIP


### PR DESCRIPTION
The missing include yielded a warning about the implicitly declared
function which was therefore defined by default to return type 'int'
which on 64-bit systems is not large enough to hold the return type
of a malloc pointer, causing the segfault when the invalid pointer
was dereferenced. Phew!

Fixes https://github.com/allinurl/goaccess/issues/1168

Signed-off-by: Joe Groocock <me@frebib.net>