### PR TITLE
Change browser compare order

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -150,7 +150,6 @@ static const char *browsers[][2] = {
   {"Chrome", "Chrome"},
 
   {"CriOS", "Chrome"},
-  {"Safari", "Safari"},
 
   /* Crawlers/Bots */
   {"bingbot", "Crawlers"},
@@ -311,6 +310,8 @@ static const char *browsers[][2] = {
   {"StatusCake", "Uptime"},
   {"internetVista", "Uptime"},
   {"Server Density Service Monitoring v2", "Uptime"},
+
+  {"Safari", "Safari"},
 
   {"Mozilla", "Others"}
 };


### PR DESCRIPTION
The baiduspider's mobile User-Agent is

"Mozilla/5.0 (Linux;u;Android 4.2.2;zh-cn;) AppleWebKit/534.46 (KHTML,like Gecko) Version/5.1 Mobile Safari/10600.6.3 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",

but it is not a Safari browser.