### PR TITLE
Fix fallback to global config

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -121,6 +121,7 @@ char *
 get_config_file_path (void)
 {
   char *upath = NULL, *rpath = NULL;
+  FILE *file;
 
   /* determine which config file to open, default or custom */
   if (conf.iconfigfile != NULL) {
@@ -138,12 +139,14 @@ get_config_file_path (void)
   }
 
   /* otherwise, fallback to global config file */
-  if (rpath == NULL && conf.load_global_config) {
+  if ((file = fopen (rpath, "r")) == NULL && conf.load_global_config) {
     upath = get_global_config ();
     rpath = realpath (upath, NULL);
     if (upath) {
       free (upath);
     }
+  } else {
+    fclose (file);
   }
 
   return rpath;


### PR DESCRIPTION
#694 results in ~/.goaccessrc always being used, the fallback to the global config file is broken. It appears that the code is assuming that realpath() will return NULL if the file does not exist, which is not the case. Unbreak by actually attempting to open ~/.goaccessrc and falling back to global config if this fails.