### PR TITLE
Fix parse_raw_data for VISITORS module when using Tokyo Cabinet

### DIFF
--- a/src/tcabdb.c
+++ b/src/tcabdb.c
@@ -1710,7 +1710,11 @@ parse_raw_data (GModule module)
   raw_data->type = type;
 
   tc_db_foreach (hash, data_iter_generic, raw_data);
-  sort_raw_num_data (raw_data, raw_data->idx);
+  if (raw_data->type == STRING) {
+    sort_raw_str_data (raw_data, raw_data->idx);
+  } else {
+    sort_raw_num_data (raw_data, raw_data->idx);
+  }
 
   return raw_data;
 }


### PR DESCRIPTION
Thanks for the great software.

I noticed that when using Tokyo Cabinet btree storage the VISITORS section of HTML report randomly changed dates. This patch fixes the issue.

The issue is shown in this youtube video: https://youtu.be/yp8jgVLTWs8