### PR TITLE
Enable out-of-tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,68 +44,76 @@ CLEANFILES =                          \
   resources/js/app.js.tmp
 
 # Tpls
-tpls.h: bin2c$(EXEEXT) resources/tpls.html
+tpls.h: bin2c$(EXEEXT) $(srcdir)/resources/tpls.html
 if HAS_SEDTR
-	cat resources/tpls.html | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/tpls.html.tmp
+	mkdir -p resources
+	cat $(srcdir)/resources/tpls.html | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/tpls.html.tmp
 	./bin2c resources/tpls.html.tmp src/tpls.h tpls
 else
-	./bin2c resources/tpls.html src/tpls.h tpls
+	./bin2c $(srcdir)/resources/tpls.html src/tpls.h tpls
 endif
 # Bootstrap
-bootstrapcss.h: bin2c$(EXEEXT) resources/css/bootstrap.min.css
+bootstrapcss.h: bin2c$(EXEEXT) $(srcdir)/resources/css/bootstrap.min.css
 if HAS_SEDTR
-	cat resources/css/bootstrap.min.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/bootstrap.min.css.tmp
+	mkdir -p resources/css
+	cat $(srcdir)/resources/css/bootstrap.min.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/bootstrap.min.css.tmp
 	./bin2c resources/css/bootstrap.min.css.tmp src/bootstrapcss.h bootstrap_css
 else
-	./bin2c resources/css/bootstrap.min.css src/bootstrapcss.h bootstrap_css
+	./bin2c $(srcdir)/resources/css/bootstrap.min.css src/bootstrapcss.h bootstrap_css
 endif
 # Font Awesome
-facss.h: bin2c$(EXEEXT) resources/css/fa.min.css
+facss.h: bin2c$(EXEEXT) $(srcdir)/resources/css/fa.min.css
 if HAS_SEDTR
-	cat resources/css/fa.min.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/fa.min.css.tmp
+	mkdir -p resources/css
+	cat $(srcdir)/resources/css/fa.min.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/fa.min.css.tmp
 	./bin2c resources/css/fa.min.css.tmp src/facss.h fa_css
 else
-	./bin2c resources/css/fa.min.css src/facss.h fa_css
+	./bin2c $(srcdir)/resources/css/fa.min.css src/facss.h fa_css
 endif
 # App.css
-appcss.h: bin2c$(EXEEXT) resources/css/app.css
+appcss.h: bin2c$(EXEEXT) $(srcdir)/resources/css/app.css
 if HAS_SEDTR
-	cat resources/css/app.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/app.css.tmp
+	mkdir -p resources/css
+	cat $(srcdir)/resources/css/app.css | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/css/app.css.tmp
 	./bin2c resources/css/app.css.tmp src/appcss.h app_css
 else
-	./bin2c resources/css/app.css src/appcss.h app_css
+	./bin2c $(srcdir)/resources/css/app.css src/appcss.h app_css
 endif
 # D3.js
-d3js.h: bin2c$(EXEEXT) resources/js/d3.v3.min.js
+d3js.h: bin2c$(EXEEXT) $(srcdir)/resources/js/d3.v3.min.js
 if HAS_SEDTR
-	cat resources/js/d3.v3.min.js | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/d3.v3.min.js.tmp
+	mkdir -p resources/js
+	cat $(srcdir)/resources/js/d3.v3.min.js | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/d3.v3.min.js.tmp
 	./bin2c resources/js/d3.v3.min.js.tmp src/d3js.h d3_js
 else
-	./bin2c resources/js/d3.v3.min.js src/d3js.h d3_js
+	./bin2c $(srcdir)/resources/js/d3.v3.min.js src/d3js.h d3_js
 endif
 # Hogan.js
-hoganjs.h: bin2c$(EXEEXT) resources/js/hogan.min.js
+hoganjs.h: bin2c$(EXEEXT) $(srcdir)/resources/js/hogan.min.js
 if HAS_SEDTR
-	cat resources/js/hogan.min.js | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/hogan.min.js.tmp
+	mkdir -p resources/js
+	cat $(srcdir)/resources/js/hogan.min.js | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/hogan.min.js.tmp
 	./bin2c resources/js/hogan.min.js.tmp src/hoganjs.h hogan_js
 else
-	./bin2c resources/js/hogan.min.js src/hoganjs.h hogan_js
+	./bin2c $(srcdir)/resources/js/hogan.min.js src/hoganjs.h hogan_js
 endif
 # Charts.js
-chartsjs.h: bin2c$(EXEEXT) resources/js/charts.js
+chartsjs.h: bin2c$(EXEEXT) $(srcdir)/resources/js/charts.js
 if HAS_SEDTR
-	cat resources/js/charts.js | sed -E "s@(,|;)[[:space:]]*//..*@\1@g" | sed -E "s@^[[:space:]]*//..*@@g" | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/charts.js.tmp
+	mkdir -p resources/js
+	cat $(srcdir)/resources/js/charts.js | sed -E "s@(,|;)[[:space:]]*//..*@\1@g" | sed -E "s@^[[:space:]]*//..*@@g" | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/charts.js.tmp
 	./bin2c resources/js/charts.js.tmp src/chartsjs.h charts_js
 else
-	./bin2c resources/js/charts.js src/chartsjs.h charts_js
+	./bin2c $(srcdir)/resources/js/charts.js src/chartsjs.h charts_js
 endif
 # App.js
-appjs.h: bin2c$(EXEEXT) resources/js/app.js
+appjs.h: bin2c$(EXEEXT) $(srcdir)/resources/js/app.js
 if HAS_SEDTR
-	cat resources/js/app.js | sed -E "s@(,|;)[[:space:]]*//..*@\1@g" | sed -E "s@^[[:space:]]*//..*@@g" | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/app.js.tmp
+	mkdir -p resources/js
+	cat $(srcdir)/resources/js/app.js | sed -E "s@(,|;)[[:space:]]*//..*@\1@g" | sed -E "s@^[[:space:]]*//..*@@g" | sed "s/^[[:space:]]*//" | sed "/^$$/d" | tr -d "\r\n" > resources/js/app.js.tmp
 	./bin2c resources/js/app.js.tmp src/appjs.h app_js
 else
-	./bin2c resources/js/app.js src/appjs.h app_js
+	./bin2c $(srcdir)/resources/js/app.js src/appjs.h app_js
 endif
 
 confdir = $(sysconfdir)/goaccess


### PR DESCRIPTION
autoconf/automake usually allows a user to do an out-of-tree build:

    mkdir build
    cd build
    ../configure
    make

This is convenient to easily start from scratch by just removing the
`build` directory (whatever we are working from a git checkout or a
tarball).

To make it work, manually written rules, like these used to embed
HTML/JS/CSS resources, need to be rewritten to correctly address
source files.