### PR TITLE
Add an option to disable client IP validation

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -520,6 +520,11 @@ ignore-panel KEYPHRASES
 #ignore-status 400
 #ignore-status 502
 
+# Disable client IP validation. Useful if IP addresses have been
+# obfuscated before being logged.
+#
+# no-ip-validation true
+
 # Number of lines from the access log to test against the provided
 # log/date/time format. By default, the parser is set to test 10
 # lines. If set to 0, the parser won't test  any  lines and will parse

--- a/goaccess.1
+++ b/goaccess.1
@@ -608,6 +608,10 @@ ww?.domain.*
 Ignore parsing and displaying one or multiple status code(s). For multiple
 status codes, use this option multiple times.
 .TP
+\fB\-\-no-ip-validation
+Disable client IP validation. Useful if IP addresses have been obfuscated before
+being logged.
+.TP
 \fB\-\-num-tests=<number>
 Number of lines from the access log to test against the provided log/date/time
 format. By default, the parser is set to test 10 lines.  If set to 0, the parser

--- a/src/options.c
+++ b/src/options.c
@@ -52,6 +52,7 @@
 #include "error.h"
 #include "labels.h"
 #include "util.h"
+
 #include "xmalloc.h"
 
 static char short_options[] = "f:e:p:o:l:H:M:S:b:"
@@ -120,6 +121,7 @@ struct option long_opts[] = {
   {"no-csv-summary"       , no_argument       , 0 ,  0  } ,
   {"no-global-config"     , no_argument       , 0 ,  0  } ,
   {"no-html-last-updated" , no_argument       , 0 ,  0  } ,
+  {"no-ip-validation"     , no_argument       , 0 ,  0  } ,
   {"no-parsing-spinner"   , no_argument       , 0 ,  0  } ,
   {"no-progress"          , no_argument       , 0 ,  0  } ,
   {"no-tab-scroll"        , no_argument       , 0 ,  0  } ,
@@ -559,6 +561,10 @@ parse_long_opt (const char *name, const char *oarg)
   if (!strcmp ("ignore-referer", name))
     set_array_opt (oarg, conf.ignore_referers, &conf.ignore_referer_idx,
                    MAX_IGNORE_REF);
+
+  /* client IP validation */
+  if (!strcmp ("no-ip-validation", name))
+    conf.no_ip_validation = 1;
 
   /* hide referer from report (e.g. within same site) */
   if (!strcmp ("hide-referer", name))

--- a/src/parser.c
+++ b/src/parser.c
@@ -1083,7 +1083,7 @@ parse_specifier (GLogItem * logitem, char **str, const char *p, const char *end)
     if (!(tkn = parse_string (&(*str), end, 1)))
       return spec_err (logitem, SPEC_TOKN_NUL, *p, NULL);
 
-    if (invalid_ipaddr (tkn, &logitem->type_ip)) {
+    if (!conf.no_ip_validation && invalid_ipaddr (tkn, &logitem->type_ip)) {
       spec_err (logitem, SPEC_TOKN_INV, *p, tkn);
       free (tkn);
       return 1;

--- a/src/settings.h
+++ b/src/settings.h
@@ -164,6 +164,7 @@ typedef struct GConf_
   int no_column_names;              /* don't show col names on termnal */
   int no_csv_summary;               /* don't show overall metrics */
   int no_html_last_updated;         /* don't show HTML last updated field */
+  int no_ip_validation;             /* don't validate client IP addresses */
   int no_parsing_spinner;           /* disable parsing spinner */
   int no_progress;                  /* disable progress metrics */
   int no_tab_scroll;                /* don't scroll dashboard on tab */


### PR DESCRIPTION
To avoid logging IP addresses, users may obfuscate them using a
regularly rotated seed and an hash algorithm. For nginx, [ipscrub][]
can be used for such a task. However, the result is not a valid IP
address.

This commit adds an option, `--no-ip-validation`, to avoid checking
the validity of an IP address and use the provided field as is. The IP
is stored as a string and the current code correctly handles the case
where this field is not an IP address (`inet_pton()` is checked with
`AF_INET`, then `AF_INET6` and falls back to some sensible behaviour
for other cases).

Fix #1354

[ipscrub]: https://github.com/masonicboom/ipscrub