### PR TITLE
Fix path to default config

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -479,8 +479,8 @@ get_global_config (void)
 {
   char *path = NULL;
 
-  path = xmalloc (snprintf (NULL, 0, "%s/goaccess.conf", SYSCONFDIR) + 1);
-  sprintf (path, "%s/goaccess.conf", SYSCONFDIR);
+  path = xmalloc (snprintf (NULL, 0, "%s/goaccess/goaccess.conf", SYSCONFDIR) + 1);
+  sprintf (path, "%s/goaccess/goaccess.conf", SYSCONFDIR);
 
   return path;
 }


### PR DESCRIPTION
Since v1.3, goaccess will install default config to `/etc/goaccess/goaccess.conf`:

https://github.com/allinurl/goaccess/blob/b43934e4a383070de936f513a06e45f424691223/Makefile.am#L119

But when goaccess is run after installation, it will look at old location, `/etc/goaccess.conf` instead.

This change fixes default config file lookup to match installed location.

Without the change, on a fresh install:

    goaccess --dcf
    No default config file found.
    You may specify one with `-p /path/goaccess.conf`

strace reveals: 

    lstat("/etc/goaccess.conf", 0x7ffe8846a0e0) = -1 ENOENT (No such file or directory)

After the change, on a fresh install:

    goaccess --dcf
    /etc/goaccess/goaccess.conf