### PR TITLE
Add base64 encoded favicon to html output

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -232,6 +232,16 @@ print_html_header (FILE * fp)
   "<meta name='viewport' content='width=device-width, initial-scale=1'>"
   "<meta name='robots' content='noindex, nofollow'>", _(DOC_LANG));
 
+  /* Output base64 encoded goaccess favicon.ico*/
+  fprintf (fp, "<link rel='icon' href='data:image/x-icon;base64,AAABAAEA"
+  "EBAQAAEABAAoAQAAFgAAACgAAAAQAAAAIAAAAAEABAAAAAAAgAAAAAAAAAAAAAAAEAAAA"
+  "AAAAADGxsYAWFhYABwcHABfAP8A/9dfAADXrwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  "AAAAAAAAAAAAAAAAAAAAAAIiIiIiIiIiIjMlUkQgAiIiIiIiIiIiIiIzJVJEIAAAIiIiI"
+  "iIiIiIiMyVSRCAAIiIiIiIiIiIiIRERERERERERERERERERERIiIiIiIiIiIgACVVUiIi"
+  "IiIiIiIiIiIiIAAlVVIiIiIiIiIiIiIiIhEREREREREREREREREREREAAAAAAAAAAAAAA"
+  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  "AA' type='image/x-icon' />");
+
   print_html_title (fp);
 
   fprintf (fp, "<style>%s</style>", fa_css);


### PR DESCRIPTION
If html file didn't have a icon link,browser may request a facicon.ico
from the root uri which may not have on the server, and it will return
a 404 error code.
this might not work for browsers lower than IE8

Fix #1432

I am not familiar with c ,this is the best i can do :)
 