### PR TITLE
Close #1362 - fix newline when print to stdout/stderr

### DIFF
--- a/src/ui.h
+++ b/src/ui.h
@@ -59,6 +59,8 @@
 #define SPIN_FMTM "%s [%'d] [%'lld/s]"
 #define SPIN_LBL 50     /* max length of the progress spinner */
 
+#define SPIN_UPDATE_INTERVAL 100000 // in microseconds
+
 /* Module JSON keys */
 #define VISITORS_ID        "visitors"
 #define REQUESTS_ID        "requests"


### PR DESCRIPTION
Closes https://github.com/allinurl/goaccess/issues/1362

Tested with ~10MB access.log file, and observed a newline added correctly:
```
$ goaccess access.log -o report.html --log-format COMBINED
Parsing...[58,556] [58,556/s]
$
```