### PR TITLE
Typo in goaccess.conf

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -480,7 +480,7 @@ double-decode false
 ignore-crawlers false
 
 # Parse and display crawlers only.
-# This will ignore robots listed under browsers.c
+# This will ignore all hosts except robots listed under browsers.c
 # Note that it will count them towards the total
 # number of requests, but excluded from any of the panels.
 #


### PR DESCRIPTION
I understand that `crawlers-only` is the opposite part to `ignore-crawlers`, so the comment can't be `This will ignore robots listed under browsers.c`?