### PR TITLE
Add DuckDuckGo and MSNBot browsers to the crawlers list.

### DIFF
--- a/config/browsers.list
+++ b/config/browsers.list
@@ -89,6 +89,8 @@ PxBroker										Crawlers
 Seekport										Crawlers
 adscanner										Crawlers
 AfD-Verbotsverfahren_JETZT!	Crawlers
+DuckDuckGo-favicons-Bot									Crawlers
+bingbot											Crawlers
 
 Vienna											Feeds
 Windows-RSS-Platform				Feeds

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -188,6 +188,8 @@ static const char *browsers[][2] = {
   {"Python", "Crawlers"},
   {"LinkedIn", "Crawlers"},
   {"Microsoft-WebDAV", "Crawlers"},
+  {"DuckDuckGo-Favicons-Bot", "Crawlers"},
+  {"bingbot", "Crawlers"},
 
   /* Podcast fetchers */
   {"Downcast", "Podcasts"},


### PR DESCRIPTION
Add crawlers that are routinely showing up as real hits to the crawlers list.