### PR TITLE
Fix build with GCC 10

### DIFF
--- a/src/commons.h
+++ b/src/commons.h
@@ -44,7 +44,7 @@
 #define GO_UNUSED __attribute__((unused))
 #define GO_VERSION 		"1.3"
 #define GO_WEBSITE 		"http://goaccess.io/"
-struct tm *now_tm;
+extern struct tm *now_tm;
 
 /* common char array buffer size */
 #define INIT_BUF_SIZE 1024

--- a/src/csv.c
+++ b/src/csv.c
@@ -55,6 +55,8 @@
 #include "ui.h"
 #include "util.h"
 
+struct tm *now_tm;
+
 /* Panel output */
 typedef struct GPanel_
 {


### PR DESCRIPTION
This patch fixes build error like this:
```
make[2]: Leaving directory '/builddir/build/BUILD/goaccess-1.3'
/usr/bin/ld: src/color.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/commons.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/csv.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/error.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/gdashboard.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/gdns.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/gholder.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/gmenu.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/goaccess.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/gstorage.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/gwsocket.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/json.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/opesys.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/options.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/output.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/parser.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/settings.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/sort.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/ui.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/util.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/websocket.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/xmalloc.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/tcabdb.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
/usr/bin/ld: src/tcbtdb.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: multiple definition of `now_tm'; src/browsers.o:/builddir/build/BUILD/goaccess-1.3/src/commons.h:47: first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:694: goaccess] Error 1
make[1]: *** [Makefile:829: all-recursive] Error 1

```

More info you can find [here](https://gcc.gnu.org/gcc-10/porting_to.html#common).