### PR TITLE
Add option user-name=username

### DIFF
--- a/goaccess.1
+++ b/goaccess.1
@@ -1,4 +1,4 @@
-.TH goaccess 1 "NOVEMBER 2018" Linux "User Manuals"
+.TH goaccess 1 "MARCH 2020" Linux "User Manuals"
 .SH NAME
 goaccess \- fast web log analyzer and interactive viewer.
 .SH SYNOPSIS
@@ -386,6 +386,13 @@ Run GoAccess as daemon (only if \fB\-\-real-time-html enabled).
 .IP
 Note: It's important to make use of absolute paths across GoAccess'
 configuration.
+.TP
+\fB\-\-user-name=<username>
+Run GoAccess as the specified user.
+.IP
+Note: It's important to ensure the user or the users' group can access the
+input and output files.
+Other groups the user belongs to will be ignored.
 .TP
 \fB\-\-origin=<url>
 Ensure clients send the specified origin header upon the WebSocket handshake.

--- a/src/options.c
+++ b/src/options.c
@@ -94,6 +94,7 @@ struct option long_opts[] = {
   {"color-scheme"         , required_argument , 0 , 0  }  ,
   {"crawlers-only"        , no_argument       , 0 , 0  }  ,
   {"daemonize"            , no_argument       , 0 , 0  }  ,
+  {"user-name"            , required_argument , 0 , 0  }  ,
   {"date-format"          , required_argument , 0 , 0  }  ,
   {"date-spec"            , required_argument , 0 , 0  }  ,
   {"dcf"                  , no_argument       , 0 , 0  }  ,
@@ -197,6 +198,7 @@ cmd_help (void)
   "Server Options\n\n"
   "  --addr=<addr>                   - Specify IP address to bind server to.\n"
   "  --daemonize                     - Run as daemon (if --real-time-html enabled).\n"
+  "  --user-name=<username>          - Run as the specified user.\n"
   "  --fifo-in=<path>                - Path to read named pipe (FIFO).\n"
   "  --fifo-out=<path>               - Path to write named pipe (FIFO).\n"
   "  --origin=<addr>                 - Ensure clients send the specified origin header\n"
@@ -418,6 +420,9 @@ parse_long_opt (const char *name, const char *oarg) {
   /* run program as a Unix daemon */
   if (!strcmp ("daemonize", name))
     conf.daemonize = 1;
+
+  if (!strcmp ("user-name", name))
+    conf.username = oarg;
 
   /* WebSocket origin */
   if (!strcmp ("origin", name))

--- a/src/settings.h
+++ b/src/settings.h
@@ -143,6 +143,7 @@ typedef struct GConf_
   int color_scheme;                 /* color scheme */
   int crawlers_only ;               /* crawlers only */
   int daemonize;                    /* run program as a Unix daemon */
+  const char *username;             /* user to run program as */
   int double_decode;                /* need to double decode */
   int enable_html_resolver;         /* html/json/csv resolver */
   int geo_db;                       /* legacy geoip db */


### PR DESCRIPTION
This makes it trivial to integrate into any OS's init system.

For example, it's not possible to launch from NetBSD's rc system as the www user because it's locked down so the su command does not work and a third party tool would be required.

It also allows pkgsrc to supply an init script so it can be daemonised easily.