### PR TITLE
Add .dmg, .xz, and .zst to the static list.

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -621,6 +621,9 @@ static-file .tiff
 static-file .tif
 static-file .ttf
 static-file .flv
+static-file .dmg
+static-file .xz
+static-file .zst
 #static-file .less
 #static-file .ac3
 #static-file .avi


### PR DESCRIPTION
.dmg is the most commonly used extention for Apple Disk Image files,
.xz is used by XZ Utils, and .zst is used by Zstandard.