### PR TITLE
README: update openSUSE instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ alternative option below.
 
 #### openSUSE  ####
 
-    # zypper ar -f obs://server:http
-    # zypper ref && zypper in goaccess
+    # zypper ar -f obs://server:http http
+    # zypper in goaccess
 
 #### OpenIndiana ####
 


### PR DESCRIPTION
The `zypper ar` line resulted in an error as a repo name is required.
Given the `-f` (autorefresh) option is specified, manually refreshing (`zypper ref`) is not really needed.