### PR TITLE
Fix definitions of combined/common log formats

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -60,17 +60,17 @@
 # NOTE: If the time/date is a timestamp in seconds or microseconds
 # %x must be used instead of %d & %t to represent the date & time.
 
-# NCSA Combined Log Format
-#log-format %h %^[%d:%t %^] "%r" %s %b "%R" "%u"
+# Apache/NCSA Combined Log Format
+#log-format %h %^ %^ [%d:%t %^] "%r" %s %b "%R" "%u"
 
-# NCSA Combined Log Format with Virtual Host
-#log-format %v:%^ %h %^[%d:%t %^] "%r" %s %b "%R" "%u"
+# Apache/NCSA Combined Log Format with Virtual Host
+#log-format %v:%^ %h %^ %^ [%d:%t %^] "%r" %s %b "%R" "%u"
 
-# Common Log Format (CLF)
-#log-format %h %^[%d:%t %^] "%r" %s %b
+# Apache/NCSA Common Log Format (CLF)
+#log-format %h %^ %^ [%d:%t %^] "%r" %s %b
 
-# Common Log Format (CLF) with Virtual Host
-#log-format %v:%^ %h %^[%d:%t %^] "%r" %s %b
+# Apache/NCSA Common Log Format (CLF) with Virtual Host
+#log-format %v:%^ %h %^ %^ [%d:%t %^] "%r" %s %b
 
 # W3C
 #log-format %d %t %h %^ %^ %^ %^ %r %^ %s %b %^ %^ %u %R

--- a/src/settings.c
+++ b/src/settings.c
@@ -62,10 +62,10 @@ static GEnum LOGTYPE[] = {
 };
 
 static const GPreConfLog logs = {
-  "%h %^[%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"",                 /* NCSA */
-  "%v:%^ %h %^[%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"",           /* NCSA + VHost  */
-  "%h %^[%d:%t %^] \"%r\" %s %b",                               /* CLF */
-  "%v:%^ %h %^[%d:%t %^] \"%r\" %s %b",                         /* CLF+VHost */
+  "%h %^ %^ [%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"",             /* Apache/NCSA Combined Log Format */
+  "%v:%^ %h %^ %^ [%d:%t %^] \"%r\" %s %b \"%R\" \"%u\"",       /* Apache/NCSA Combined Log Format + VHost */
+  "%h %^ %^ [%d:%t %^] \"%r\" %s %b",                           /* Apache/NCSA Common Log Format */
+  "%v:%^ %h %^ %^ [%d:%t %^] \"%r\" %s %b",                     /* Apache/NCSA Common Log Format + VHost */
   "%d %t %^ %m %U %q %^ %^ %h %u %R %s %^ %^ %L",               /* W3C */
   "%d\\t%t\\t%^\\t%b\\t%h\\t%m\\t%^\\t%r\\t%s\\t%R\\t%u\\t%^",  /* CloudFront */
   "\"%x\",\"%h\",%^,%^,\"%m\",\"%U\",\"%s\",%^,\"%b\",\"%D\",%^,\"%R\",\"%u\"", /* Cloud Storage */


### PR DESCRIPTION
These formats have two initial fields to ignore (the RFC 1413 identity and
the HTTP authenticated user).