### PR TITLE
Sigsegv

### DIFF
--- a/src/error.h
+++ b/src/error.h
@@ -89,6 +89,7 @@ void invalid_fprintf (const char *fmt, ...) __attribute__((format (printf, 1, 2)
 void invalid_log_close (void);
 void invalid_log_open (const char *path);
 void set_signal_data (void *p);
-void sigsegv_handler (int sig) __attribute__((noreturn));
+void setup_sigsegv_handler(void);
+void sigsegv_handler (int sig);
 
 #endif

--- a/src/gkhash.c
+++ b/src/gkhash.c
@@ -3090,11 +3090,13 @@ parse_raw_data (GModule module) {
   switch (module) {
   case VISITORS:
     raw_data = get_str_raw_data (module);
-    sort_raw_str_data (raw_data, raw_data->idx);
+    if (raw_data)
+      sort_raw_str_data (raw_data, raw_data->idx);
     break;
   default:
     raw_data = get_u32_raw_data (module);
-    sort_raw_num_data (raw_data, raw_data->idx);
+    if (raw_data)
+      sort_raw_num_data (raw_data, raw_data->idx);
   }
 
   modstr = get_module_str (module);

--- a/src/goaccess.c
+++ b/src/goaccess.c
@@ -1274,18 +1274,6 @@ parse_cmd_line (int argc, char **argv) {
   set_default_static_files ();
 }
 
-/* Set up signal handlers. */
-static void
-setup_signal_handlers (void) {
-  struct sigaction act;
-
-  sigemptyset (&act.sa_mask);
-  act.sa_flags = 0;
-  act.sa_handler = sigsegv_handler;
-
-  sigaction (SIGSEGV, &act, NULL);
-}
-
 static void
 handle_signal_action (GO_UNUSED int sig_number) {
   fprintf (stderr, "\nSIGINT caught!\n");
@@ -1424,7 +1412,7 @@ main (int argc, char **argv) {
   int quit = 0, ret = 0;
 
   block_thread_signals ();
-  setup_signal_handlers ();
+  setup_sigsegv_handler ();
 
   /* command line/config options */
   verify_global_config (argc, argv);


### PR DESCRIPTION
* Rework sigsegv handler
  Do not exit immediately, instead call previously set sigsegv handler,
  which might be a handler provided by a third party tool like ASAN.

  Example extended crash output::

```==23351== GoAccess 1.4 crashed by Sig 11
==23351==
==23351== VALUES AT CRASH POINT
==23351==
==23351== Line number: 10000
==23351== Offset: 10000
==23351== Invalid data: 0
==23351== Piping: 0
==23351==
==23351== STACK TRACE:
==23351==
==23351== 0 ./goaccess(backtrace+0x5b) [0x45d88b]
==23351== 1 ./goaccess(sigsegv_handler+0x14a) [0x4d9dca]
==23351== 2 /lib/x86_64-linux-gnu/libpthread.so.0(+0x14110) [0x7f4ed7e4c110]
==23351== 3 ./goaccess(parse_raw_data+0x5d) [0x50bd3d]
==23351== 4 ./goaccess() [0x54c896]
==23351== 5 ./goaccess() [0x552d3f]
==23351== 6 ./goaccess() [0x550bb5]
==23351== 7 ./goaccess() [0x54fc26]
==23351== 8 ./goaccess() [0x54a9d1]
==23351== 9 ./goaccess(main+0x2b4) [0x549c74]
==23351== 10 /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xeb) [0x7f4ed7b2ae0b]
==23351== 11 ./goaccess(_start+0x2a) [0x42686a]
==23351==
==23351== Please report it by opening an issue on GitHub:
==23351== https://github.com/allinurl/goaccess/issues

AddressSanitizer:DEADLYSIGNAL
=================================================================
==23351==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010 (pc 0x00000050bd3d bp 0x7ffef6429050 sp 0x7ffef6429030 T0)
==23351==The signal is caused by a READ memory access.
==23351==Hint: address points to the zero page.
    #0 0x50bd3d in parse_raw_data /home/christian/Coding/workspaces/goaccess/src/gkhash.c:3097:44
    #1 0x54c895 in allocate_holder_by_module /home/christian/Coding/workspaces/goaccess/src/goaccess.c:303:14
    #2 0x552d3e in expand_module_from_ypos /home/christian/Coding/workspaces/goaccess/src/goaccess.c:524:3
    #3 0x550bb4 in expand_on_mouse_click /home/christian/Coding/workspaces/goaccess/src/goaccess.c:541:5
    #4 0x54fc25 in get_keys /home/christian/Coding/workspaces/goaccess/src/goaccess.c:1060:7
    #5 0x54a9d0 in curses_output /home/christian/Coding/workspaces/goaccess/src/goaccess.c:1171:3
    #6 0x549c73 in main /home/christian/Coding/workspaces/goaccess/src/goaccess.c:1469:5
    #7 0x7f4ed7b2ae0a in __libc_start_main csu/../csu/libc-start.c:308:16
    #8 0x426869 in _start (/home/christian/Coding/workspaces/goaccess/goaccess+0x426869)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/christian/Coding/workspaces/goaccess/src/gkhash.c:3097:44 in parse_raw_data
==23351==ABORTING
```

*  Fix crash in mouse enabled mode
   Fixes: #1818

   There might be a logic issue hiding, cause while testing some times the wrong section got expanded.

