### PR TITLE
Log filepath on error

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2084,7 +2084,7 @@ gen_vhost_key (GKeyData * kdata, GLogItem * logitem) {
  *
  * On error, 1 is returned.
  * On success, the generated userid key is assigned to our key data
- * structure. */
+ * structure. */f
 static int
 gen_remote_user_key (GKeyData * kdata, GLogItem * logitem) {
   if (!logitem->userid)
@@ -2728,7 +2728,7 @@ read_log (GLog ** glog, const char *fn, int dry_run) {
 
   /* make sure we can open the log (if not reading from stdin) */
   if (!piping && (fp = fopen (fn, "r")) == NULL)
-    FATAL ("Unable to open the specified log file. %s", strerror (errno));
+    FATAL ("Unable to open the specified log file '%s'. %s", fn, strerror (errno));
 
   /* grab the inode of the file being parsed */
   if (!piping && stat (fn, &fdstat) == 0)


### PR DESCRIPTION
I'm trying to use the dockerized version of goaccess but currently it fails with `Unable to open the specified log file. No such file or directory`. Since I'm not 100% sure about which log file it considers, having it in the error message can help!