### PR TITLE
Remove license statement in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,3 @@
-# Copyright 2019 Hiroki Kamino.
-# Originally under MIT in Gerardo Orellana. https://goaccess.io/
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 FROM alpine:edge AS builds
 RUN apk add --no-cache \
     autoconf \


### PR DESCRIPTION
Removed license statement in the `Dockerfile` to conform to the primary license.
