### PR TITLE
Fix missing libmaxminddb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache \
     gettext-static \
     git \
     libmaxminddb-dev \
+    libmaxminddb-static \
     libressl-dev \
     linux-headers \
     ncurses-dev \


### PR DESCRIPTION
Fix problem with Docker image build failure because `libmaxminddb` was not found.
