### PR TITLE
POSIX has made usleep(2) obsolete in favour of nanosleep(2)

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -560,7 +560,7 @@ parse_long_opt (const char *name, const char *oarg) {
     uint64_t ref = strtoull (oarg, &sEnd, 10);
     if (oarg == sEnd || *sEnd != '\0' || errno == ERANGE)
       return;
-    conf.html_refresh = ref >= 1 && ref <= 60 ? 1000000 * ref : 0;
+    conf.html_refresh = ref >= 1 && ref <= 60 ? ref : 0;
   }
 
   /* specifies the path of the database file */

--- a/src/options.h
+++ b/src/options.h
@@ -32,7 +32,7 @@
 
 #define CYN   "\x1B[36m"
 #define RESET "\x1B[0m"
-#define HTML_REFRESH 1000000    /* 1s */
+#define HTML_REFRESH 1    /* in seconds */
 
 void add_dash_filename (void);
 void cmd_help (void) __attribute__((noreturn));

--- a/src/ui.h
+++ b/src/ui.h
@@ -60,7 +60,7 @@
 #define SPIN_FMTM "[%s %s] {%'"PRIu64"} @ {%'lld/s}"
 #define SPIN_LBL 256    /* max length of the progress spinner */
 
-#define SPIN_UPDATE_INTERVAL 100000     // in microseconds
+#define SPIN_UPDATE_INTERVAL 100000000     /* in nanoseconds */
 
 /* Module JSON keys */
 #define VISITORS_ID        "visitors"


### PR DESCRIPTION
usleep(2) also has no effect if equal to greater than 1000000
which happens to match HTML_REFERS, but no error was checked.
This caused 100% CPU utiliation constantly following the tail
of the web server access log with default value.

nanosleep(2) has more relaxed limits.
This commit does a like for like replacement and also adds
error checking in case of a similar error in the future.

Signed-off-by: Roy Marples <roy@marples.name>