### PR TITLE
Detect SHA1Init in libc and use that instead of our own sources

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -166,8 +166,6 @@ goaccess_SOURCES = \
    src/pdjson.h        \
    src/settings.c      \
    src/settings.h      \
-   src/sha1.c          \
-   src/sha1.h          \
    src/sort.c          \
    src/sort.h          \
    src/tpl.c           \
@@ -180,6 +178,12 @@ goaccess_SOURCES = \
    src/websocket.h     \
    src/xmalloc.c       \
    src/xmalloc.h
+
+if USE_SHA1
+goaccess_SOURCES +=  \
+   src/sha1.c        \
+   src/sha1.h
+endif
 
 if USE_MMAP
 goaccess_SOURCES +=  \

--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,11 @@ esac
 AC_MSG_RESULT([$with_rdyanimc])
 AM_CONDITIONAL([WITH_RDYNAMIC], [test "x$with_rdyanimc" = "xyes"])
 
+# Check for libc implementation on NetBSD
+AC_CHECK_HEADERS([sha.h sha1.h])
+AC_CHECK_FUNCS([SHA1Init])
+AM_CONDITIONAL([USE_SHA1], [test "x$ac_cv_func_SHA1Init" != "xyes"])
+
 # Build with OpenSSL
 AC_ARG_WITH([openssl],[AS_HELP_STRING([--with-openssl],[Build with OpenSSL support. Default is disabled])],[openssl="$withval"],[openssl="no"])
 


### PR DESCRIPTION
This allows goaccess to be built with address sanitisation on NetBSD, otherwise it would not know which SHA1 functions to use.