### PR TITLE
add some browsers

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -122,6 +122,8 @@ static const char *browsers[][2] = {
   {"libwww-perl", "Others"},
   {"python-requests", "Others"},
   {"PackageKit", "Others"},
+  {"F-Droid", "Others"},
+  {"okhttp", "Others"},
 
   /* Feed-reader-as-a-service */
   {"AppleNewsBot", "Feeds"},
@@ -138,6 +140,8 @@ static const char *browsers[][2] = {
   {"theoldreader.com", "Feeds"},
   {"WordPress.com Reader", "Feeds"},
   {"YandexBlogs", "Feeds"},
+  {"Brainstorm", "Feeds"},
+  {"Pleroma", "Feeds"},
 
   /* Google crawlers (some based on Chrome,
    * therefore up on the list) */
@@ -152,6 +156,8 @@ static const char *browsers[][2] = {
   /* Rebranded Firefox but is really unmodified
    * Firefox (Debian trademark policy) */
   {"Iceweasel", "Firefox"},
+  {"Waterfox", "Firefox"},
+  {"PaleMoon", "Firefox"},
   {"Focus", "Firefox"},
   /* Klar is the name of Firefox Focus in the German market. */
   {"Klar", "Firefox"},


### PR DESCRIPTION
This massively reduces the "unknown" entries in the browser section of my reports.

* Waterfox & PaleMoon are Firefox forks, so I assigned them to "Firefox"
* Pleroma is used by the decentralized, mastodon compatible Pleroma (when fetching "link previews" for the timeline I guess), Brainstorm seems to be a bot fetching content for Reddit, Mastodon & Matrix – hence I assigned both to "Feeds"
* F-Droid is used by the official [F-Droid](https://f-droid.org/) Android client, okhttp by several Android apps – hence assigned to "Others"

"F-Droid" will probably only show up on servers providing F-Droid app repositories. I'm running such a repo, hence I'm interested in having it defined – but if that's not wanted "globally" I fully understand and would "patch" it on my end before compile, just let me now if you want it removed.