### PR TITLE
Allow goaccess to be cross compiled.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,8 @@ dist_noinst_DATA =                 \
   resources/js/d3.v3.min.js        \
   resources/js/hogan.min.js
 
-noinst_PROGRAMS = bin2c
-bin2c_SOURCES = src/bin2c.c
+bin2c$(EXEEXT): src/bin2c.c
+	$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $< -o $@ $(LDFLAGS_FOR_BUILD)
 
 BUILT_SOURCES =       \
   src/tpls.h          \

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Distro                 | NCurses          | GeoIP (opt)      |GeoIP2 (opt)      
 **Gentoo**             | sys-libs/ncurses | dev-libs/geoip   | dev-libs/libmaxminddb |  dev-libs/openssl
 **Slackware**          | ncurses          | GeoIP            | libmaxminddb          |  openssl
 
-**Note**: You may need to install build tools like `gcc`, `autoconf`,
+**Note**: You may need to install build tools like `gcc`, `autoconf`, `autoconf-archive`
 `gettext`, `autopoint` etc for compiling/building software from source. e.g.,
 `base-devel`, `build-essential`, `"Development Tools"`.
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,9 @@ AC_CONFIG_HEADERS([src/config.h])
 AC_PROG_CC([cc gcc clang])
 AM_PROG_CC_C_O
 
+# Find build compiler for the cross compilation case
+AX_CC_FOR_BUILD
+
 # Check for programs
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19])


### PR DESCRIPTION
When cross compiling, bin2c needs to be built for the build system, so
building it with the CC compiler won't work. We use an autoconf macro in
order to obtain a good value for CC_FOR_BUILD, and define a rule using
it directly instead.

Reference
https://www.gnu.org/software/autoconf-archive/ax_cc_for_build.html

---

If you want to avoid the dependency on `autoconf-archive` for the new macro, the logic is reasonably easy to replicate.

I noticed that `bin2c.c` has some code for using bzip2, but I don't think that can be enabled in any way, at least for now?