### PR TITLE
Change to neutral term

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 What is it?
 -------------
-GoAccess is an open source real-time web log analyzer and interactive viewer
+GoAccess is a FLOSS real-time web log analyzer and interactive viewer
 that runs in a terminal in *nix systems or through your browser.
 
 It provides fast and valuable HTTP statistics for system administrators that

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ GoAccess [![Build Status](https://travis-ci.org/allinurl/goaccess.svg?branch=mas
 ========
 
 ## What is it? ##
-GoAccess is an open source **real-time web log analyzer** and interactive
+GoAccess is a FLOSS **real-time web log analyzer** and interactive
 viewer that runs in a **terminal** on &ast;nix systems or through your
 **browser**. It provides **fast** and valuable HTTP statistics for system
 administrators that require a visual server report on the fly.

--- a/goaccess.1
+++ b/goaccess.1
@@ -6,7 +6,7 @@ goaccess \- fast web log analyzer and interactive viewer.
 .B goaccess [filename] [options...] [-c][-M][-H][-q][-d][...]
 .SH DESCRIPTION
 .B goaccess
-GoAccess is an open source real-time web log analyzer and interactive viewer
+GoAccess is a FLOSS real-time web log analyzer and interactive viewer
 that runs in a
 .I terminal
 in *nix systems or through your


### PR DESCRIPTION
"Open source" is a term used to show support for open source, whereas "free" or "libre" are terms used to show support for the free software movement.

I assume goaccess wants to remain neutral, so I switched all mentions of "open source" to the neutral term "FLOSS" (free (libre) and open source software).

Please see also:
https://www.gnu.org/philosophy/words-to-avoid.html#FLOSS
https://www.gnu.org/philosophy/floss-and-foss.html