### PR TITLE
Don't call unknown Linux systems "GNU+Linux"

### DIFF
--- a/src/opesys.c
+++ b/src/opesys.c
@@ -99,8 +99,8 @@ static const char *os[][2] = {
   {"OpenBSD", "BSD"},
   {"DragonFly", "BSD"},
 
-  {"Linux", "GNU+Linux"},
-  {"linux", "GNU+Linux"},
+  {"Linux", "Linux"},
+  {"linux", "Linux"},
 
   {"PlayStation", "BSD"},
 


### PR DESCRIPTION
Should fix #2075