### PR TITLE
Add a new category for Unix

### DIFF
--- a/src/opesys.c
+++ b/src/opesys.c
@@ -98,16 +98,18 @@ static const char *os[][2] = {
   {"NetBSD", "BSD"},
   {"OpenBSD", "BSD"},
   {"DragonFly", "BSD"},
+  
+  {"PlayStation", "BSD"},
 
   {"Linux", "Linux"},
   {"linux", "Linux"},
 
-  {"PlayStation", "BSD"},
-
   {"CrOS", "Chrome OS"},
-  {"SunOS", "Unix-like"},
   {"QNX", "Unix-like"},
   {"BB10", "Unix-like"},
+  
+  {"AIX", "Unix"},
+  {"SunOS", "Unix"},
 
   {"BlackBerry", "Others"},
   {"Sony", "Others"},


### PR DESCRIPTION
Solaris/SunOS/illumos is an actual UNIX, not just "Unix-like"; also, added AIX (which is still alive).