### PR TITLE
Dark Mode detection

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -51,7 +51,7 @@ window.GoAccess = window.GoAccess || {
 			'autoHideTables': true,
 			'layout': cw > 2560 ? 'wide' : 'horizontal',
 			'perPage': 7,
-			'theme': 'darkPurple',
+			'theme': (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'darkPurple' : 'bright',
 		};
 		this.AppPrefs = GoAccess.Util.merge(this.AppPrefs, this.opts.prefs);
 


### PR DESCRIPTION
GoAccess defaults to the darkPurple theme even for us weirdos :-) who still prefer the Light Mode in 2021. This change defaults to "bright" for us and "darkPurple" for them.