### PR TITLE
add scoop.it

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -236,7 +236,7 @@ static const char *browsers[][2] = {
   {"Googlebot-Image", "Crawlers"},
   {"ZmEu", "Crawlers"},
   {"DowntimeDetector", "Crawlers"},
-
+  {"Scoop.it", "Crawlers"},
 
   /* Podcast fetchers */
   {"Downcast", "Podcasts"},


### PR DESCRIPTION
This seems to be the crawler of the homonym website and it hit my website a lot last month. That is also the full browser User-Agent:

```
   3410 [BR]   Scoop.it
   1705 [OS]   Scoop.it
```

I'm not sure if it would make more sense to put together in the same PR multiple different User-Agents or not.
Also, I did add this one to the end of its list as it seems to be the convention, but I'm not sure this makes sense in the long run. Maybe it would be easier to manage the list if they were alphabetically sorted. If agreed, I can create a new PR sorting them!