### PR TITLE
Rename referer to referrer in goaccess.conf

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -465,10 +465,10 @@ double-decode false
 #enable-panel MIME_TYPE
 #enable-panel TLS_TYPE
 
-# Hide a referer but still count it. Wild cards are allowed. i.e., *.bing.com
+# Hide a referrer but still count it. Wild cards are allowed. i.e., *.bing.com
 #
-#hide-referer *.google.com
-#hide-referer bing.com
+#hide-referrer *.google.com
+#hide-referrer bing.com
 
 # Hour specificity. Possible values: `hr` (default), or `min` (tenth
 # of a minute).
@@ -516,13 +516,13 @@ ignore-panel KEYPHRASES
 #ignore-panel MIME_TYPE
 #ignore-panel TLS_TYPE
 
-# Ignore referers from being counted.
+# Ignore referrers from being counted.
 # This supports wild cards. For instance,
 # '*' matches 0 or more characters (including spaces)
 # '?' matches exactly one character
 #
-#ignore-referer *.domain.com
-#ignore-referer ww?.domain.*
+#ignore-referrer *.domain.com
+#ignore-referrer ww?.domain.*
 
 # Ignore parsing and displaying one or multiple status code(s)
 #


### PR DESCRIPTION
Now that GoAccess prefers "referrer" over "referer", the example configuration file should probably cover that.