### PR TITLE
Check item.hits in map_data to protect against divide by zero

### DIFF
--- a/src/gholder.c
+++ b/src/gholder.c
@@ -420,6 +420,8 @@ map_data (GModule module, GRawDataItem item, datatype type, char **data, uint32_
   case U32:
     if (!(*data = ht_get_datamap (module, item.nkey)))
       return 1;
+    if (!item.hits)
+      return 1;
     *hits = item.hits;
     break;
   case STR:


### PR DESCRIPTION
See [issue 2106](https://github.com/allinurl/goaccess/issues/2106).