### PR TITLE
Add an option to classify unknown OS and browsers as crawlers

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -510,6 +510,10 @@ ignore-crawlers false
 #
 crawlers-only false
 
+# Unknown browsers and OS are considered as crawlers
+#
+unknowns-as-crawlers false
+
 # Ignore static file requests.
 # req : Only ignore request from valid requests
 # panels : Ignore request from panels.

--- a/goaccess.1
+++ b/goaccess.1
@@ -662,6 +662,9 @@ traffic on your server at specific times.
 \fB\-\-ignore-crawlers
 Ignore crawlers from being counted.
 .TP
+\fB\-\-unknowns-as-crawlers
+Classify unknown OS and browsers as crawlers.
+.TP
 \fB\-\-ignore-panel=<PANEL>
 Ignore parsing and displaying the given panel.
 .IP

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <stddef.h>
 
+#include "opesys.h"
 #include "browsers.h"
 
 #include "error.h"
@@ -403,17 +404,34 @@ parse_browsers_file (void) {
  * If it is a crawler, 1 is returned . */
 int
 is_crawler (const char *agent) {
-  char type[BROWSER_TYPE_LEN];
-  char *browser, *a;
+  char btype[BROWSER_TYPE_LEN];
+  char otype[OPESYS_TYPE_LEN];
+  char *browser, *os, *a;
 
   if (agent == NULL || *agent == '\0')
     return 0;
 
-  if ((a = xstrdup (agent), browser = verify_browser (a, type)) != NULL)
+  if ((a = xstrdup (agent), browser = verify_browser (a, btype)) != NULL)
     free (browser);
   free (a);
 
-  return strcmp (type, "Crawlers") == 0 ? 1 : 0;
+  if (strcmp (btype, "Crawlers") == 0)
+    return 1;
+
+  if (!conf.unknowns_as_crawlers)
+    return 0;
+
+  if (strcmp (btype, "Unknown") == 0)
+    return 1;
+
+  if ((a = xstrdup (agent), os = verify_os (a, otype)) != NULL)
+    free (os);
+  free (a);
+
+  if (strcmp (otype, "Unknown") == 0)
+    return 1;
+
+  return 0;
 }
 
 /* Return the Opera 15 and beyond.

--- a/src/options.c
+++ b/src/options.c
@@ -143,6 +143,7 @@ struct option long_opts[] = {
   {"sort-panel"           , required_argument , 0 , 0  }  ,
   {"static-file"          , required_argument , 0 , 0  }  ,
   {"tz"                   , required_argument , 0 , 0  }  ,
+  {"unknowns-as-crawlers" , no_argument       , 0 , 0  }  ,
   {"user-name"            , required_argument , 0 , 0  }  ,
 #ifdef HAVE_LIBSSL
   {"ssl-cert"             , required_argument , 0 ,  0  } ,
@@ -312,6 +313,7 @@ cmd_help (void)
   "                                    See manpage for a list of panels/fields.\n"
   "  --static-file=<extension>       - Add static file extension. e.g.: .mp3.\n"
   "                                    Extensions are case sensitive.\n"
+  "  --unknowns-as-crawlers          - Classify unknown OS and browsers as crawlers.\n"
   "\n"
 
 /* GeoIP Options */
@@ -684,6 +686,10 @@ parse_long_opt (const char *name, const char *oarg) {
       conf.static_file_max_len = strlen (oarg);
     set_array_opt (oarg, conf.static_files, &conf.static_file_idx, MAX_EXTENSIONS);
   }
+
+  /* classify unknowns as crawlers */
+  if (!strcmp ("unknowns-as-crawlers", name))
+    conf.unknowns_as_crawlers = 1;
 
   /* GEOIP OPTIONS
    * ========================= */

--- a/src/settings.h
+++ b/src/settings.h
@@ -161,6 +161,7 @@ typedef struct GConf_
   int geo_db;                       /* legacy geoip db */
   int hl_header;                    /* highlight header on term */
   int ignore_crawlers;              /* ignore crawlers */
+  int unknowns_as_crawlers;         /* unknown OS and browsers are classified as crawlers */
   int ignore_qstr;                  /* ignore query string */
   int ignore_statics;               /* ignore static files */
   int json_pretty_print;            /* pretty print JSON data */


### PR DESCRIPTION
As an attempt to detect non-humans more accurately, an option to
classify unknown OS and browsers and crawlers help. In my case, I have
20% visitors with unknown OS and 12% with unknown browser. Here is the
top list from last month:

```
    509 python-requests/2.25.1
    534 googlebot
    563 Mozilla/5.0 (compatible; CensysInspect/1.1;  https://about.censys.io/)
    567 WordPress/5.1.5; https://takefive.cn
    573 http.rb/4.4.1
    612 MB-Web-Crawler
    624 GoodBot
    624 lanaibot please contact contactlanaibot@gmail.com for information
    709 Mozilla/5.0 (compatible; SEOkicks;  https://www.seokicks.de/robot.html)
    762 https://github.com/blakeembrey/popsicle
    768 Mozilla/5.0 (compatible; Neevabot/1.0;  https://neeva.com/neevabot)
    891 MauiBot (crawler.feedback wc@gmail.com)
    933 Buck/2.2; ( https://app.hypefactors.com/media-monitoring/about.html)
   1119 Scrapy/2.5.0 ( https://scrapy.org)
   1341 colly - https://github.com/gocolly/colly
   1734 omgili/0.5  http://omgili.com
   2766 unirest-java/1.3.11
   4341 got (https://github.com/sindresorhus/got)
   5352 Go 1.1 package http
   7143 newspaper/0.2.8
  10197 -
```

It would be possible to detect more as I still have some more users
with IE9 than IE11 (which is not possible, since I am requiring TLS
1.2).

The option could be extended with an optional argument to ignore more
OS and browsers (like "Others" and "Feeds"). So, I am unsure if the
name is the right one. At first, I wanted to extend
`--ignore-crawlers` with an optional argument, but `--crawlers-only`
makes it non suitable. Alternatively, we could have
`--also-crawlers=Unknown,Others,Feeds`.