### PR TITLE
Enable local site-search and support for lowercasing searches

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -137,6 +137,8 @@ struct option long_opts[] = {
   {"real-time-html"       , no_argument       , 0 , 0  }  ,
   {"restore"              , no_argument       , 0 , 0  }  ,
   {"sort-panel"           , required_argument , 0 , 0  }  ,
+  {"site-search"          , no_argument       , 0 , 0  }  ,
+  {"site-search-lower"    , no_argument       , 0 , 0  }  ,
   {"static-file"          , required_argument , 0 , 0  }  ,
   {"user-name"            , required_argument , 0 , 0  }  ,
 #ifdef HAVE_LIBSSL
@@ -260,6 +262,8 @@ cmd_help (void)
   "  --process-and-exit              - Parse log and exit without outputting data.\n"
   "  --real-os                       - Display real OS names. e.g, Windows XP, Snow Leopard.\n"
   "  --restore                       - Restore data from disk from the given --db-path or from /tmp.\n"
+  "  --site-search                   - Parse search keyphrases for a local site search using q URL param\n"
+  "  --site-search-lower             - Lower case search keyphrases from local site search\n"
   "  --sort-panel=PANEL,METRIC,ORDER - Sort panel on initial load. e.g., --sort-panel=VISITORS,BY_HITS,ASC.\n"
   "                                    See manpage for a list of panels/fields.\n"
   "  --static-file=<extension>       - Add static file extension. e.g.: .mp3. Extensions are case sensitive.\n"
@@ -599,6 +603,14 @@ parse_long_opt (const char *name, const char *oarg) {
       conf.static_file_max_len = strlen (oarg);
     set_array_opt (oarg, conf.static_files, &conf.static_file_idx, MAX_EXTENSIONS);
   }
+
+  /* local site search */
+  if (!strcmp ("site-search", name))
+    conf.site_search = 1;
+
+  /* lowercase local site search */
+  if (!strcmp ("site-search-lower", name))
+    conf.site_search_lower = 1;
 
   /* GEOIP OPTIONS
    * ========================= */

--- a/src/options.c
+++ b/src/options.c
@@ -606,13 +606,13 @@ parse_long_opt (const char *name, const char *oarg) {
 
   /* local site search */
   if (!strcmp ("site-search", name)) {
-	char *first_param = xstrdup ("?");
-	char *other_param = xstrdup ("&");
+    char *first_param = xstrdup ("?");
+    char *other_param = xstrdup ("&");
 
-	append_str(&first_param, oarg);
-	append_str(&first_param, "=");
-	append_str(&other_param, oarg);
-	append_str(&other_param, "=");
+    append_str(&first_param, oarg);
+    append_str(&first_param, "=");
+    append_str(&other_param, oarg);
+    append_str(&other_param, "=");
 
     conf.site_search = first_param;
     conf.site_search_other = other_param;

--- a/src/options.c
+++ b/src/options.c
@@ -137,7 +137,7 @@ struct option long_opts[] = {
   {"real-time-html"       , no_argument       , 0 , 0  }  ,
   {"restore"              , no_argument       , 0 , 0  }  ,
   {"sort-panel"           , required_argument , 0 , 0  }  ,
-  {"site-search"          , no_argument       , 0 , 0  }  ,
+  {"site-search"          , required_argument , 0 , 0  }  ,
   {"site-search-lower"    , no_argument       , 0 , 0  }  ,
   {"static-file"          , required_argument , 0 , 0  }  ,
   {"user-name"            , required_argument , 0 , 0  }  ,
@@ -262,7 +262,7 @@ cmd_help (void)
   "  --process-and-exit              - Parse log and exit without outputting data.\n"
   "  --real-os                       - Display real OS names. e.g, Windows XP, Snow Leopard.\n"
   "  --restore                       - Restore data from disk from the given --db-path or from /tmp.\n"
-  "  --site-search                   - Parse search keyphrases for a local site search using q URL param\n"
+  "  --site-search=<param>           - Parse search terms for local site search with query param (usually q)\n"
   "  --site-search-lower             - Lower case search keyphrases from local site search\n"
   "  --sort-panel=PANEL,METRIC,ORDER - Sort panel on initial load. e.g., --sort-panel=VISITORS,BY_HITS,ASC.\n"
   "                                    See manpage for a list of panels/fields.\n"
@@ -605,8 +605,18 @@ parse_long_opt (const char *name, const char *oarg) {
   }
 
   /* local site search */
-  if (!strcmp ("site-search", name))
-    conf.site_search = 1;
+  if (!strcmp ("site-search", name)) {
+	char *first_param = xstrdup ("?");
+	char *other_param = xstrdup ("&");
+
+	append_str(&first_param, oarg);
+	append_str(&first_param, "=");
+	append_str(&other_param, oarg);
+	append_str(&other_param, "=");
+
+    conf.site_search = first_param;
+    conf.site_search_other = other_param;
+  }
 
   /* lowercase local site search */
   if (!strcmp ("site-search-lower", name))

--- a/src/parser.c
+++ b/src/parser.c
@@ -344,10 +344,11 @@ extract_sitesearch_keyphrase (char *ref, char **keyphrase) {
   int encoded = 0;
 
   /* Find start of keyword */
-  if ((r = strstr (ref, "&q=")) != NULL || (r = strstr (ref, "?q=")) != NULL)
-    r += 3;
-  else if ((r = strstr (ref, "%26q%3D")) != NULL || (r = strstr (ref, "%3Fq%3D")) != NULL)
-    encoded = 1, r += 7;
+  if ((r = strstr (ref, conf.site_search)) != NULL || (r = strstr (ref, 
+				  conf.site_search_other)) != NULL)
+    r += strlen(conf.site_search);
+  // else if ((r = strstr (ref, "%26q%3D")) != NULL || (r = strstr (ref, "%3Fq%3D")) != NULL)
+  //  encoded = 1, r += 7;
   else
     return 1;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -178,6 +178,8 @@ typedef struct GConf_
   int real_time_html;               /* enable real-time HTML output */
   int restore;                      /* reload data from db-path */
   int skip_term_resolver;           /* no terminal resolver */
+  int site_search;                  /* enable local site search keywords parsing */
+  int site_search_lower;            /* lower case local site search keywords */
   int is_json_log_format;           /* is a json log format */
   uint32_t keep_last;               /* number of days to keep in storage */
   uint32_t num_tests;               /* number of lines to test */

--- a/src/settings.h
+++ b/src/settings.h
@@ -178,7 +178,8 @@ typedef struct GConf_
   int real_time_html;               /* enable real-time HTML output */
   int restore;                      /* reload data from db-path */
   int skip_term_resolver;           /* no terminal resolver */
-  int site_search;                  /* enable local site search keywords parsing */
+  const char *site_search;          /* enable local site search keywords parsing */
+  const char *site_search_other;    /* alternate matching for site search param */
   int site_search_lower;            /* lower case local site search keywords */
   int is_json_log_format;           /* is a json log format */
   uint32_t keep_last;               /* number of days to keep in storage */

--- a/src/util.c
+++ b/src/util.c
@@ -925,6 +925,24 @@ strtoupper (char *str) {
   return str;
 }
 
+/* Make a string lowercase.
+ *
+ * On error the original string is returned.
+ * On success, the lowercased string is returned. */
+char *
+strtolower (char *str) {
+  char *p = str;
+  if (str == NULL || *str == '\0')
+    return str;
+
+  while (*p != '\0') {
+    *p = tolower (*p);
+    p++;
+  }
+
+  return str;
+}
+
 /* Left-pad a string with n amount of spaces.
  *
  * On success, a left-padded string is returned. */

--- a/src/util.h
+++ b/src/util.h
@@ -76,6 +76,7 @@ char *replace_str (const char *str, const char *old, const char *new);
 char *rtrim (char *s);
 char *secs_to_str (int secs);
 char *strtoupper(char *str);
+char *strtolower(char *str);
 char *substring (const char *str, int begin, int len);
 char *trim_str (char *str);
 char *u322str (uint32_t d, int width);


### PR DESCRIPTION
A rough start at supporting local site searches (ala #96 for other search engines) , that are making use of the same query param ('q') as Google search.

Not sure if would be better as a new output instead of overriding the Google table ?

Have also added downcasing of the search term which sometimes makes results more useful for us. This might be a niche concern.