### PR TITLE
Avoid buffer underflow

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -454,7 +454,7 @@ verify_static_content (const char *req) {
       continue;
     }
 
-    if (!strncasecmp (nul - elen, ext, elen))
+    if (nul - req > elen && !strncasecmp (nul - elen, ext, elen))
       return 1;
   }
 


### PR DESCRIPTION
Check if requested string is long enough for comparison.

    ==65303==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000013a4d at pc 0x00000043e1cb bp 0x7ffe4e3c09a0 sp 0x7ffe4e3c0140
    READ of size 1 at 0x602000013a4d thread T0
        #0 0x43e1ca in __interceptor_strncasecmp (/home/christian/Coding/workspaces/goaccess/goaccess+0x43e1ca)
        #1 0x5922e0 in verify_static_content /home/christian/Coding/workspaces/goaccess/src/parser.c
        #2 0x5922e0 in is_static /home/christian/Coding/workspaces/goaccess/src/parser.c:1487:10
        #3 0x58ecbc in pre_process_log /home/christian/Coding/workspaces/goaccess/src/parser.c:1775:12
        #4 0x593bd5 in read_line /home/christian/Coding/workspaces/goaccess/src/parser.c:1797:14
        #5 0x593bd5 in read_lines /home/christian/Coding/workspaces/goaccess/src/parser.c:1914:16
        #6 0x593bd5 in read_log /home/christian/Coding/workspaces/goaccess/src/parser.c:2008:7
        #7 0x593bd5 in parse_log /home/christian/Coding/workspaces/goaccess/src/parser.c:2059:9
        #8 0x55c83a in main /home/christian/Coding/workspaces/goaccess/src/goaccess.c:1612:14
        #9 0x7f00dae96e49 in __libc_start_main csu/../csu/libc-start.c:314:16
        #10 0x4289d9 in _start (/home/christian/Coding/workspaces/goaccess/goaccess+0x4289d9)

    0x602000013a4d is located 3 bytes to the left of 3-byte region [0x602000013a50,0x602000013a53)
    allocated by thread T0 here:
        #0 0x4a519d in malloc (/home/christian/Coding/workspaces/goaccess/goaccess+0x4a519d)
        #1 0x61d38a in xmalloc /home/christian/Coding/workspaces/goaccess/src/xmalloc.c:46:14
        #2 0x61d569 in xstrdup /home/christian/Coding/workspaces/goaccess/src/xmalloc.c:58:9
        #3 0x59b1ac in decode_url /home/christian/Coding/workspaces/goaccess/src/parser.c:325:19
        #4 0x59b6a3 in parse_req /home/christian/Coding/workspaces/goaccess/src/parser.c:559:16
        #5 0x5978df in parse_specifier /home/christian/Coding/workspaces/goaccess/src/parser.c:1026:20
        #6 0x5904aa in parse_format /home/christian/Coding/workspaces/goaccess/src/parser.c:1382:18
        #7 0x58dc07 in pre_process_log /home/christian/Coding/workspaces/goaccess/src/parser.c:1743:11
        #8 0x593bd5 in read_line /home/christian/Coding/workspaces/goaccess/src/parser.c:1797:14
        #9 0x593bd5 in read_lines /home/christian/Coding/workspaces/goaccess/src/parser.c:1914:16
        #10 0x593bd5 in read_log /home/christian/Coding/workspaces/goaccess/src/parser.c:2008:7
        #11 0x593bd5 in parse_log /home/christian/Coding/workspaces/goaccess/src/parser.c:2059:9
        #12 0x55c83a in main /home/christian/Coding/workspaces/goaccess/src/goaccess.c:1612:14
        #13 0x7f00dae96e49 in __libc_start_main csu/../csu/libc-start.c:314:16