### PR TITLE
Fix minor time-of-use / time-of-check "bug" in src/parser.c

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -434,12 +434,12 @@ clean:
  * On success, the 1 is returned. */
 static int
 verify_static_content (const char *req) {
+  if ((req == NULL) || (*req == '\0'))
+    return 0;
+
   const char *nul = req + strlen (req);
   const char *ext = NULL, *pch = NULL;
   int elen = 0, i;
-
-  if ((req == NULL) || (*req == '\0'))
-    return 0;
 
   for (i = 0; i < conf.static_file_idx; ++i) {
     ext = conf.static_files[i];


### PR DESCRIPTION
This PR will fix a tiny 'problem' with checking pointer-validity "too late", i.e. after it is already dereferenced.

See https://github.com/allinurl/goaccess/blob/master/src/parser.c#L435

Problem:  pointer 'req' is dereferenced (at line 437 by `strlen(req)`) before being checked against NULL (at line 441)
Solution: move check up before use, e.g. move if-stmt at line 441 to line 437 so that this code

```C
  435  static int
  436  verify_static_content (const char *req) {
  437    const char *nul = req + strlen (req); // <-- dereferences pointer 'req'
  438    const char *ext = NULL, *pch = NULL;
  439    int elen = 0, i;
  440  
  441    if ((req == NULL) || (*req == '\0'))  // <-- check validity of pointer 'req' (after it was dereferenced)
  442      return 0;
```

... becomes

```C
  435  static int
  436  verify_static_content (const char *req) {
  437    if ((req == NULL) || (*req == '\0')) // <-- check validity of pointer 'req' before it gets dereferenced
  438      return 0;
  439
  440    const char *nul = req + strlen (req);
  441    const char *ext = NULL, *pch = NULL;
  442    int elen = 0, i;
```

Otherwise, if `req == NULL` the program will crash/segfault at the `strlen(req);` before reaching the if-statement and returning 0.

