### PR TITLE
Docker realtime requires tail instead of cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ A Docker image has been updated, capable of directing output from an access log.
 
 OR real-time
 
-    cat access.log | docker run -p 7890:7890 --rm -i -e LANG=$LANG allinurl/goaccess -a -o html --log-format COMBINED --real-time-html - > report.html
+    tail -f access.log | docker run -p 7890:7890 --rm -i -e LANG=$LANG allinurl/goaccess -a -o html --log-format COMBINED --real-time-html - > report.html
 
 You can read more about using the docker image in [DOCKER.md](https://github.com/allinurl/goaccess/blob/master/DOCKER.md).
 


### PR DESCRIPTION
Realtime requires the usage of tail instead of cat. Otherwise there are no updates