### PR TITLE
Misc

### DIFF
--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -810,7 +810,7 @@ get_kdata (GKeyData * kdata, const char *data_key, const char *data) {
   /* inserted in datamap */
   kdata->data = data;
   /* inserted in keymap */
-  kdata->dhash = djb2 ((unsigned char *) data_key);
+  kdata->dhash = djb2 ((const unsigned char *) data_key);
 }
 
 /* A wrapper to assign the given data key and the data item to the key
@@ -820,7 +820,7 @@ get_kroot (GKeyData * kdata, const char *root_key, const char *root) {
   /* inserted in datamap */
   kdata->root = root;
   /* inserted in keymap */
-  kdata->rhash = djb2 ((unsigned char *) root_key);
+  kdata->rhash = djb2 ((const unsigned char *) root_key);
 }
 
 /* Generate a visitor's key given the date specificity. For instance,

--- a/src/labels.h
+++ b/src/labels.h
@@ -465,7 +465,7 @@
 #define STATUS_CODE_417               \
   N_("417 - Expectation Failed")
 #define STATUS_CODE_418               \
-  N_("418 - I’m a teapot")
+  N_("418 - I'm a teapot")
 #define STATUS_CODE_421               \
   N_("421 - Misdirected Request")
 #define STATUS_CODE_422               \

--- a/src/ui.c
+++ b/src/ui.c
@@ -871,7 +871,7 @@ load_host_agents (const char *addr) {
   GAgents *agents = NULL;
   GSLList *keys = NULL, *list = NULL;
   void *data = NULL;
-  uint32_t items = 4, key = djb2 ((unsigned char *) addr);
+  uint32_t items = 4, key = djb2 ((const unsigned char *) addr);
 
   keys = ht_get_keymap_list_from_key (HOSTS, key);
   if (!keys)

--- a/src/util.c
+++ b/src/util.c
@@ -217,7 +217,7 @@ __attribute__((no_sanitize ("unsigned-integer-overflow")))
 #endif
 #endif
   uint32_t
-djb2 (unsigned char *str) {
+djb2 (const unsigned char *str) {
   uint32_t hash = 5381;
   int c;
 

--- a/src/util.h
+++ b/src/util.h
@@ -99,7 +99,7 @@ int str_to_time (const char *str, const char *fmt, struct tm *tm);
 int valid_output_type (const char *filename);
 off_t file_size (const char *filename);
 size_t append_str (char **dest, const char *src);
-uint32_t djb2(unsigned char *str);
+uint32_t djb2(const unsigned char *str);
 uint32_t ip_to_binary (const char *ip);
 void genstr(char *dest, size_t len);
 void strip_newlines (char *str);

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -27,6 +27,10 @@
  * SOFTWARE.
  */
 
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #ifndef WEBSOCKET_H_INCLUDED
 #define WEBSOCKET_H_INCLUDED
 


### PR DESCRIPTION
* Drop unicode character from status description

* Mark djb2 parameter const

  Improve const correctness by declaring the read-only parameter to djb2 const.

* Include config.h to define HAVE_LIBSSL

  It seems to work so far cause all translation units using any of the HAVE_LIBSSL dependent fields are including config.h before websocket.h.