### PR TITLE
Add additional bots to crawlers

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -246,6 +246,7 @@ static const char *browsers[][2] = {
   {"SeznamBot", "Crawlers"},
   {"coccocbot", "Crawlers"},
   {"Neevabot", "Crawlers"},
+  {"Mail.RU_Bot", "Crawlers"},
 
 
   /* Podcast fetchers */

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -242,6 +242,7 @@ static const char *browsers[][2] = {
   {"MauiBot", "Crawlers"},
   {"Cloud", "Crawlers"},
   {"stagefright", "Crawlers"},
+  {"DataForSeoBot", "Crawlers"},
 
 
   /* Podcast fetchers */

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -247,6 +247,7 @@ static const char *browsers[][2] = {
   {"coccocbot", "Crawlers"},
   {"Neevabot", "Crawlers"},
   {"Mail.RU_Bot", "Crawlers"},
+  {"CCBot", "Crawlers"},
 
 
   /* Podcast fetchers */

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -243,6 +243,7 @@ static const char *browsers[][2] = {
   {"Cloud", "Crawlers"},
   {"stagefright", "Crawlers"},
   {"DataForSeoBot", "Crawlers"},
+  {"SeznamBot", "Crawlers"},
 
 
   /* Podcast fetchers */

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -245,6 +245,7 @@ static const char *browsers[][2] = {
   {"DataForSeoBot", "Crawlers"},
   {"SeznamBot", "Crawlers"},
   {"coccocbot", "Crawlers"},
+  {"Neevabot", "Crawlers"},
 
 
   /* Podcast fetchers */

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -248,6 +248,7 @@ static const char *browsers[][2] = {
   {"Neevabot", "Crawlers"},
   {"Mail.RU_Bot", "Crawlers"},
   {"CCBot", "Crawlers"},
+  {"Cincraw", "Crawlers"},
 
 
   /* Podcast fetchers */

--- a/src/browsers.c
+++ b/src/browsers.c
@@ -244,6 +244,7 @@ static const char *browsers[][2] = {
   {"stagefright", "Crawlers"},
   {"DataForSeoBot", "Crawlers"},
   {"SeznamBot", "Crawlers"},
+  {"coccocbot", "Crawlers"},
 
 
   /* Podcast fetchers */


### PR DESCRIPTION
add various additional crawlers/bots:

DataForSeoBot - https://dataforseo.com/dataforseo-bot
SeznamBot - http://napoveda.seznam.cz/en/seznambot-intro/
coccocbot - http://help.coccoc.com/searchengine
Neevabot - https://neeva.com/neevabot
Mail.RU_Bot - http://go.mail.ru/help/robots
CCBot - http://go.mail.ru/help/robots
Cincraw - http://cincrawdata.net/bot/