### PR TITLE
Added the ability to hide panels on report

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -154,6 +154,33 @@ nav .nav-ws-status {
 .nav-ws-status.connected {
 	color: #5DB56A;
 }
+nav li {
+	position: relative;
+}
+nav li .toggle-panel {
+	position: absolute;
+	padding: 9px 20px;
+	top: 0;
+	right: 50px;
+	visibility: hidden;
+	opacity: 0;
+	transition: all .2s;
+}
+nav li .toggle-panel i {
+	color: rgba(200,200,200,.5);
+	opacity: 0;
+}
+nav li .toggle-panel.active i {
+	color: #eee;
+	opacity: 1;
+}
+nav.active li .toggle-panel {
+	visibility: visible;
+	opacity: 1;
+}
+nav.active li:hover .toggle-panel i {
+	opacity: 1;
+}
 nav li a {
 	border-left: 3px solid transparent;
 	color: rgba(200,200,200,.5);
@@ -172,7 +199,7 @@ nav.active li a {
 	max-width: 100%;
 	opacity: 1;
 }
-nav li a:hover,
+nav li:hover a,
 nav li.active a {
 	background: rgba(0,0,0,.1);
 	border-color: #5BC0DE;

--- a/resources/tpls.html
+++ b/resources/tpls.html
@@ -199,10 +199,10 @@
 
 <!-- TPL Nav Bar wrapper -->
 <script id="tpl-nav-wrap" type="text/template">
+	<div class="nav-list"></div>
 	<div class="nav-bars fa fa-bars"></div>
 	<div class="nav-gears fa fa-cog"></div>
 	<div class="nav-ws-status fa fa-circle"></div>
-	<div class="nav-list"></div>
 	<div class="powered hidden-xs hidden-sm">by <a href="https://goaccess.io/">GoAccess</a> <span>v{{version}}</span> and <a href="http://gwsocket.io/">GWSocket</a></div>
 </script>
 
@@ -210,9 +210,15 @@
 <script id="tpl-nav-menu" type="text/template">
 	<h3>{{labels.panels}}</h3>
 	<ul>
-		<li {{#overall}}class="active"{{/overall}}><a href="#"><i class="fa fa-bar-chart"></i> {{labels.thead}}</a></li>
+		<li {{#overall_current}}class="active"{{/overall_current}}>
+			<a href="#"><i class="fa fa-bar-chart"></i> {{labels.thead}}</a>
+			<span class="toggle-panel {{#overall_hidden}}active{{/overall_hidden}}" data-panel="general"><i class="fa fa-circle-o"></i></span>
+		</li>
 		{{#nav}}
-		<li {{#current}}class="active"{{/current}}><a href="#{{key}}"><i class="fa fa-{{icon}}"></i> {{head}}</a></li>
+		<li {{#current}}class="active"{{/current}}>
+			<a href="#{{key}}"><i class="fa fa-{{icon}}"></i> {{head}}</a>
+			<span class="toggle-panel {{#hidden}}active{{/hidden}}" data-panel="{{key}}"><i class="fa fa-circle-o"></i></span>
+		</li>
 		{{/nav}}
 	</ul>
 </script>


### PR DESCRIPTION
GoAccess provides a lot of information in the reports, which is very useful and serves many users. Therefore, reports contain multiple panels, some of them may not be useful for some users or at a given time. There are already options to control the displayed panels, but they can only be set when generating the report.

This PR allows users to toggle panels on reports at any time by clicking on a icon on the sidebar panel list.

![image](https://user-images.githubusercontent.com/59319979/154700315-b2310d53-5fef-4e90-9381-7ab1e2829900.png)
