### PR TITLE
Show city with the DBIP City Lite database too.

### DIFF
--- a/src/geoip2.c
+++ b/src/geoip2.c
@@ -90,7 +90,7 @@ init_geoip (void) {
     FATAL ("Unable to open GeoIP2 database %s: %s\n", fn, MMDB_strerror (status));
   }
 
-  if (strcmp (mmdb->metadata.database_type, "GeoLite2-City") == 0)
+  if (strstr (mmdb->metadata.database_type, "-City") != NULL)
     geoip_city_type = 1;
 }
 


### PR DESCRIPTION
Currently, goaccess will only display host cities if the geoip database type id matches Maxmind's. This relaxes the check to match the DBIP City Lite database as well.