### PR TITLE
Add option --ping-interval=<secs>

### DIFF
--- a/goaccess.1
+++ b/goaccess.1
@@ -443,6 +443,9 @@ By default, it will attempt to connect to the generated report's hostname. If
 GoAccess is running on a remote server, the host of the remote server should be
 specified here. Also, make sure it is a valid host and NOT an http address.
 .TP
+\fB\-\-ping-interval=<secs>
+Enable WebSocket ping with specified interval in seconds.
+.TP
 \fB\-\-fifo-in=<path/file>
 Creates a named pipe (FIFO) that reads from on the given path/file.
 .TP

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -91,6 +91,12 @@ window.GoAccess = window.GoAccess || {
 
 		var socket = new WebSocket(str);
 		socket.onopen = function (event) {
+			if (wsConn.ping_interval) {
+				setInterval(() => {
+					socket.send('ping');
+				}, wsConn.ping_interval * 1000);
+			}
+			
 			GoAccess.Nav.WSOpen();
 		}.bind(this);
 

--- a/src/options.c
+++ b/src/options.c
@@ -146,6 +146,7 @@ struct option long_opts[] = {
 #endif
   {"time-format"          , required_argument , 0 ,  0  } ,
   {"ws-url"               , required_argument , 0 ,  0  } ,
+  {"ping-interval"        , required_argument , 0 ,  0  } ,
 #ifdef HAVE_GEOLOCATION
   {"geoip-database"       , required_argument , 0 ,  0  } ,
 #endif
@@ -207,6 +208,7 @@ cmd_help (void)
   "  --ssl-key=<priv.key>            - Path to TLS/SSL private key.\n"
   "  --user-name=<username>          - Run as the specified user.\n"
   "  --ws-url=<url>                  - URL to which the WebSocket server responds.\n"
+  "  --ping-interval=<secs>          - Enable WebSocket ping with specified interval in seconds.\n"
   "\n"
   ""
   /* File Options */
@@ -461,6 +463,10 @@ parse_long_opt (const char *name, const char *oarg) {
   /* URL to which the WebSocket server responds. */
   if (!strcmp ("ws-url", name))
     conf.ws_url = oarg;
+
+  /* WebSocket ping interval in seconds */
+  if (!strcmp ("ping-interval", name))
+    conf.ping_interval = oarg;
 
   /* FILE OPTIONS
    * ========================= */

--- a/src/output.c
+++ b/src/output.c
@@ -507,7 +507,7 @@ print_conn_def (FILE * fp) {
   fpopen_obj (fp, sp);
   fpskeysval (fp, "url", (conf.ws_url ? conf.ws_url : ""), sp, 0);
   fpskeyival (fp, "port", (conf.port ? atoi (conf.port) : 7890), sp, 0);
-  fpskeyival (fp, "ping_interval", (conf.ping_interval ? atoi (conf.ping_interval) : ""), sp, 1);
+  fpskeyival (fp, "ping_interval", (conf.ping_interval ? atoi (conf.ping_interval) : 0), sp, 1);
   fpclose_obj (fp, sp, 1);
 
   fprintf (fp, "</script>");

--- a/src/output.c
+++ b/src/output.c
@@ -506,7 +506,8 @@ print_conn_def (FILE * fp) {
 
   fpopen_obj (fp, sp);
   fpskeysval (fp, "url", (conf.ws_url ? conf.ws_url : ""), sp, 0);
-  fpskeyival (fp, "port", (conf.port ? atoi (conf.port) : 7890), sp, 1);
+  fpskeyival (fp, "port", (conf.port ? atoi (conf.port) : 7890), sp, 0);
+  fpskeyival (fp, "ping_interval", (conf.ping_interval ? atoi (conf.ping_interval) : ""), sp, 1);
   fpclose_obj (fp, sp, 1);
 
   fprintf (fp, "</script>");

--- a/src/settings.h
+++ b/src/settings.h
@@ -138,6 +138,7 @@ typedef struct GConf_
   const char *sslcert;              /* TLS/SSL path to certificate */
   const char *sslkey;               /* TLS/SSL path to private key */
   const char *ws_url;               /* WebSocket URL */
+  const char *ping_interval;        /* WebSocket ping interval in seconds */
   const char *unix_socket;          /* unix socket to bind to */
 
   /* User flags */


### PR DESCRIPTION
Solves #1663

Some notes:
- there is no way to send "real" ping/pong frames (sections 5.5.2 and 5.5.3 of [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2)) with the JavaScript WebSocket API - further discussion [here](https://stackoverflow.com/questions/10585355/sending-websocket-ping-pong-frame-from-browser)

- the implemented ping mechanism consists in sending plain text from the client-side JavaScript WebSocket; this is because [gwsocket.io](https://gwsocket.io/) (server-side) already supports standardized ping/pong frames as shown below:

  https://github.com/allinurl/goaccess/blob/b30282947bacff987407a71aeb4c5f7a47e6cdf3/src/websocket.h#L151-L152

  https://github.com/allinurl/goaccess/blob/b30282947bacff987407a71aeb4c5f7a47e6cdf3/src/websocket.c#L1912-L1919

  so I thought it was best not to tweak this behavior and simply play around it, in case in the future it becomes possible to send standardized ping/pong frames with the JavaScript WebSocket API