### PR TITLE
Update Dockerfile build stage to use alpine:3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 AS builds
+FROM alpine:3 AS builds
 RUN apk add --no-cache \
     autoconf \
     automake \


### PR DESCRIPTION
Alpine 3.13 will no longer regularly receive security fixes after November 1st.