### PR TITLE
Update german Translation and init inlang

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,46 @@
+// init the inlang.config
+
+/**
+ * @type {import("@inlang/core/config").DefineConfig}
+ */
+export async function defineConfig(env) {
+  // importing plugin from local file for testing purposes
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/jannesblobel/inlang-plugin-po@1/dist/index.js"
+  );
+  const pluginConfig = {
+    // language mean the name of you file
+    pathPattern: "./po/{language}.po",
+    referenceResourcePath: "./po/goaccess.pot",
+  };
+
+  return {
+    // if your project use a pot file use the pot as the reference Language
+    // !! do not add the pot file in the Languages array
+    /**
+ * @example
+ * example files: en.pot, de.po, es.po, fr.po
+ *  referenceLanguage: "en",
+    languages: ["de","es","fr"],
+ */
+    referenceLanguage: "en",
+    languages: await getLanguages(env),
+    readResources: (args) =>
+      plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) =>
+      plugin.writeResources({ ...args, ...env, pluginConfig }),
+  };
+}
+
+/**
+ * Automatically derives the languages in this repository.
+ */
+async function getLanguages(env) {
+  const files = await env.$fs.readdir("./po");
+  // files that end with .json
+  // remove the .json extension to only get language name
+  const languages = files
+    .filter((name) => name.endsWith(".po"))
+    .map((name) => name.replace(".po", ""));
+  return languages;
+}

--- a/po/de.po
+++ b/po/de.po
@@ -181,7 +181,7 @@ msgstr "Stadt"
 
 #: src/labels.h:90 src/labels.h:206 src/labels.h:210
 msgid "ASN"
-msgstr ""
+msgstr "ASN"
 
 #: src/labels.h:91
 msgid "Country"

--- a/po/de.po
+++ b/po/de.po
@@ -1,8 +1,3 @@
-# German (Formal) - GNU gettext translation file
-# Copyright (C) 2019 GoAccess <https://goaccess.io/>
-# This file is distributed under the same license as the GoAccess package.
-# Axel Wehner <mail@axelwehner.de>, 2019.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -12,7 +7,7 @@ msgstr ""
 "Last-Translator: Axel Wehner <mail@axelwehner.de>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.2.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
@@ -88,7 +83,7 @@ msgstr "Fehlgeschlagene Anfragen"
 
 #: src/labels.h:64
 msgid "Log Parsing Time"
-msgstr ""
+msgstr "Loggen der Übertragungszeit "
 
 #: src/labels.h:65
 msgid "Log Size"
@@ -215,7 +210,8 @@ msgstr "Eindeutige Besucher pro Tag - Inklusive Spiders/Bots"
 #: src/labels.h:103
 msgid "Hits having the same IP, date and agent are a unique visit."
 msgstr ""
-"Zugriffe mit der selben IP, Datum und User-Agent sind ein eindeutiger Besuch."
+"Zugriffe mit der selben IP, Datum und User-Agent sind ein eindeutiger "
+"Besuch."
 
 #: src/labels.h:108
 msgid "Requested Files (URLs)"
@@ -238,8 +234,8 @@ msgstr "Statische Anfragen"
 #: src/labels.h:117
 msgid "Top static requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
 msgstr ""
-"Häufigste statische Anfragen sortiert nach Zugriffen [, avgts, cumts, maxts, "
-"mthd, proto]"
+"Häufigste statische Anfragen sortiert nach Zugriffen [, avgts, cumts, "
+"maxts, mthd, proto]"
 
 #: src/labels.h:122
 msgid "Time Distribution"
@@ -293,8 +289,7 @@ msgstr "Besucher Hostnames und IPs"
 
 #: src/labels.h:159
 msgid "Top visitor hosts sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Häufigste Besucher-Hosts sortiert nach Zugriffen [, avgts, cumts, maxts]"
+msgstr "Häufigste Besucher-Hosts sortiert nach Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:161
 msgid "Hosts"
@@ -306,8 +301,7 @@ msgstr "Betriebssysteme"
 
 #: src/labels.h:166
 msgid "Top Operating Systems sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Häufigste Betriebssysteme sortiert nach Zugriffen [, avgts, cumts, maxts]"
+msgstr "Häufigste Betriebssysteme sortiert nach Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:168
 msgid "OS"
@@ -330,7 +324,8 @@ msgstr "Verweis-URLs"
 #, fuzzy
 msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
-"Häufigste ausgehende Verweise sortiert nach Zugriffen [, avgts, cumts, maxts]"
+"Häufigste ausgehende Verweise sortiert nach Zugriffen [, avgts, cumts, "
+"maxts]"
 
 #: src/labels.h:182
 #, fuzzy
@@ -344,7 +339,8 @@ msgstr "Verweisende Seiten"
 #: src/labels.h:187
 msgid "Top Referring Sites sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
-"Häufigste eingehende Verweise sortiert nach Zugriffen [, avgts, cumts, maxts]"
+"Häufigste eingehende Verweise sortiert nach Zugriffen [, avgts, cumts, "
+"maxts]"
 
 #: src/labels.h:192
 msgid "Keyphrases from Google's search engine"
@@ -352,8 +348,7 @@ msgstr "Schlüsselwörter von Google's Suchmaschine"
 
 #: src/labels.h:194
 msgid "Top Keyphrases sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Häufigste Schlüsselwörter sortiert nach Zugriffen [, avgts, cumts, maxts]"
+msgstr "Häufigste Schlüsselwörter sortiert nach Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:196
 msgid "Keyphrases"
@@ -365,8 +360,7 @@ msgstr "Geo-Standort"
 
 #: src/labels.h:201
 msgid "Continent > Country sorted by unique hits [, avgts, cumts, maxts]"
-msgstr ""
-"Kontinent > Land sortiert nach eindeutigen Zugriffen [, avgts, cumts, maxts]"
+msgstr "Kontinent > Land sortiert nach eindeutigen Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:208
 msgid "Autonomous System Numbers/Organizations (ASNs)"
@@ -378,8 +372,7 @@ msgstr "HTTP-Statuscodes"
 
 #: src/labels.h:215
 msgid "Top HTTP Status Codes sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Häufigste HTTP Status Codes sortiert nach Zugriffen [, avgts, cumts, maxts]"
+msgstr "Häufigste HTTP Status Codes sortiert nach Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:217
 msgid "Status Codes"
@@ -702,8 +695,7 @@ msgstr "5xx Serverfehler"
 
 #: src/labels.h:404
 msgid "100 - Continue: Server received the initial part of the request"
-msgstr ""
-"100 - Weitermachen: Der Server hat den ersten Teil der Anfrage erhalten"
+msgstr "100 - Weitermachen: Der Server hat den ersten Teil der Anfrage erhalten"
 
 #: src/labels.h:406
 msgid "101 - Switching Protocols: Client asked to switch protocols"
@@ -786,8 +778,7 @@ msgstr "400 - Fehlerhafte Anfrage: Die Syntax der Anfrage ist ungültig"
 
 #: src/labels.h:444
 msgid "401 - Unauthorized: Request needs user authentication"
-msgstr ""
-"401 - Nicht autorisiert: Anforderung erfordert Benutzerauthentifizierung"
+msgstr "401 - Nicht autorisiert: Anforderung erfordert Benutzerauthentifizierung"
 
 #: src/labels.h:446
 msgid "402 - Payment Required"
@@ -799,8 +790,7 @@ msgstr "403 - Verboten: Der Server weigert sich, darauf zu reagieren"
 
 #: src/labels.h:450
 msgid "404 - Not Found: Requested resource could not be found"
-msgstr ""
-"404 - Nicht gefunden: Angefragte Ressource konnte nicht gefunden werden"
+msgstr "404 - Nicht gefunden: Angefragte Ressource konnte nicht gefunden werden"
 
 #: src/labels.h:452
 msgid "405 - Method Not Allowed: Request method not supported"
@@ -834,8 +824,7 @@ msgstr "411 - Erforderliche Länge: Ungültige Inhaltslänge"
 
 #: src/labels.h:466
 msgid "412 - Precondition Failed: Server does not meet preconditions"
-msgstr ""
-"412 - Vorbedingung fehlgeschlagen: Server erfüllt nicht die Voraussetzungen"
+msgstr "412 - Vorbedingung fehlgeschlagen: Server erfüllt nicht die Voraussetzungen"
 
 #: src/labels.h:468
 msgid "413 - Payload Too Large"
@@ -847,8 +836,7 @@ msgstr "414 - Anfrage-URI zu lang"
 
 #: src/labels.h:472
 msgid "415 - Unsupported Media Type: Media type is not supported"
-msgstr ""
-"415 - Nicht unterstützter Medientyp: Der Medientyp wird nicht unterstützt"
+msgstr "415 - Nicht unterstützter Medientyp: Der Medientyp wird nicht unterstützt"
 
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
@@ -871,8 +859,7 @@ msgstr "421 - Fehlgesteuerte Anfrage"
 
 #: src/labels.h:482
 msgid "422 - Unprocessable Entity due to semantic errors: WebDAV"
-msgstr ""
-"422 - Nicht verarbeitbare Entität aufgrund von semantischen Fehlern: WebDAV"
+msgstr "422 - Nicht verarbeitbare Entität aufgrund von semantischen Fehlern: WebDAV"
 
 #: src/labels.h:484
 msgid "423 - The resource that is being accessed is locked"
@@ -940,8 +927,7 @@ msgstr "501 - Nicht implementiert"
 
 #: src/labels.h:514
 msgid "502 - Bad Gateway: Received an invalid response from the upstream"
-msgstr ""
-"502 - Fehlerhaftes Gateway: Eine ungültige Antwort vom Upstream erhalten"
+msgstr "502 - Fehlerhaftes Gateway: Eine ungültige Antwort vom Upstream erhalten"
 
 #: src/labels.h:516
 msgid "503 - Service Unavailable: The server is currently unavailable"
@@ -976,15 +962,3 @@ msgstr "523 - CloudFlare - Herkunft ist unerreichbar"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - Zeitüberschreitung aufgetreten"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Init. Verarbeitungszeit"
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr "Erstellt in Verwendung der Standard In-Memory Hash-Datenbank."
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "Erstellt in Verwendung des Tokyo Cabinet on-disk B+ Tree."
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr "Erstellt in Verwendung der Tokyo Cabinet In-Memory Hash-Datenbank."

--- a/po/de.po
+++ b/po/de.po
@@ -364,7 +364,7 @@ msgstr "Kontinent > Land sortiert nach eindeutigen Zugriffen [, avgts, cumts, ma
 
 #: src/labels.h:208
 msgid "Autonomous System Numbers/Organizations (ASNs)"
-msgstr ""
+msgstr "Autonome Systemnummern/Organisationen (ASNs)"
 
 #: src/labels.h:213
 msgid "HTTP Status Codes"

--- a/po/de.po
+++ b/po/de.po
@@ -127,7 +127,7 @@ msgstr "Zugriffe"
 
 #: src/labels.h:77
 msgid "h%"
-msgstr ""
+msgstr "h%"
 
 #: src/labels.h:78 src/labels.h:105
 msgid "Visitors"

--- a/po/de.po
+++ b/po/de.po
@@ -599,7 +599,7 @@ msgstr "Tabellen auf kleinen Bildschirmen automatisch verstecken"
 
 #: src/labels.h:353
 msgid "Toggle Panel"
-msgstr ""
+msgstr "Panel umschalten"
 
 #: src/labels.h:355
 msgid "Layout"

--- a/po/de.po
+++ b/po/de.po
@@ -139,7 +139,7 @@ msgstr "Bes."
 
 #: src/labels.h:80
 msgid "v%"
-msgstr ""
+msgstr "v%"
 
 # T.S. = Time Serve (The time taken to serve the request)
 # Vz = Verarbeitungszeit

--- a/po/de.po
+++ b/po/de.po
@@ -271,7 +271,7 @@ msgstr "Cache Status des gelieferten Objekts"
 
 #: src/labels.h:147
 msgid "Cache Status"
-msgstr ""
+msgstr "Cache status"
 
 #: src/labels.h:150
 msgid "Not Found URLs (404s)"

--- a/po/es.po
+++ b/po/es.po
@@ -1,8 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: Goaccess\n"
@@ -13,7 +8,7 @@ msgstr ""
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
 
@@ -716,8 +711,7 @@ msgstr "204 - Sin Contenido: Peticion no retorno ningun contenido"
 
 #: src/labels.h:418
 msgid "205 - Reset Content: Server asked the client to reset the document"
-msgstr ""
-"205 - Resetear Contenido: Servidor pidio al cliente resetear el documento"
+msgstr "205 - Resetear Contenido: Servidor pidio al cliente resetear el documento"
 
 #: src/labels.h:420
 msgid "206 - Partial Content: The partial GET has been successful"
@@ -917,13 +911,11 @@ msgstr "502 - Entrada Erronea: Recibio respuesta invalida"
 
 #: src/labels.h:516
 msgid "503 - Service Unavailable: The server is currently unavailable"
-msgstr ""
-"503 - Servicio no disponible: El servidor actualmente no esta disponible"
+msgstr "503 - Servicio no disponible: El servidor actualmente no esta disponible"
 
 #: src/labels.h:518
 msgid "504 - Gateway Timeout: The upstream server failed to send request"
-msgstr ""
-"504 - Timeout de Gateway: El servidor upstream fallo al enviar peticion"
+msgstr "504 - Timeout de Gateway: El servidor upstream fallo al enviar peticion"
 
 #: src/labels.h:520
 msgid "505 - HTTP Version Not Supported"
@@ -948,24 +940,3 @@ msgstr "523 - CloudFlare - Origen es inaccesible"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - Ocurrio cese de tiempo"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Hora Inicio Proc."
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr "Construido usando base de datos hash por defecto en-memoria"
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "Construido usando Tokyo Cabinet on-disk B+ Tree."
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr "Construido usando Tokyo Cabinet in-memory hash database."
-
-#~ msgid "Bandwidth"
-#~ msgstr "Ancho de Banda"
-
-#~ msgid "Unique Files"
-#~ msgstr "Archivos Unicos"
-
-#~ msgid "Unique 404"
-#~ msgstr "404 Unico"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,7 +1,3 @@
-# This file is distributed under the same license as the goaccess package.
-# Nicolas P <np>, 2017.
-# Coban L 2020
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.4\n"
@@ -12,7 +8,7 @@ msgstr ""
 "Language-Team: français\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -209,8 +205,7 @@ msgstr "Visiteurs uniques/jour - Y compris bots"
 
 #: src/labels.h:103
 msgid "Hits having the same IP, date and agent are a unique visit."
-msgstr ""
-"Les hits depuis la même IP, date et user-agent comptent comme visite unique"
+msgstr "Les hits depuis la même IP, date et user-agent comptent comme visite unique"
 
 #: src/labels.h:108
 msgid "Requested Files (URLs)"
@@ -231,7 +226,8 @@ msgstr "Requêtes statiques"
 #: src/labels.h:117
 msgid "Top static requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
 msgstr ""
-"Top des requêtes statiques trié par hits [, avgts, cumts, maxts, mthd, proto]"
+"Top des requêtes statiques trié par hits [, avgts, cumts, maxts, mthd, "
+"proto]"
 
 #: src/labels.h:122
 msgid "Time Distribution"
@@ -275,8 +271,7 @@ msgstr "URLs Non trouvées (404s)"
 
 #: src/labels.h:152
 msgid "Top not found URLs sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"Top des URLs non trouvées trié par hits [, avgts, cumts, maxts, mthd, proto]"
+msgstr "Top des URLs non trouvées trié par hits [, avgts, cumts, maxts, mthd, proto]"
 
 #: src/labels.h:157
 msgid "Visitor Hostnames and IPs"
@@ -588,8 +583,7 @@ msgstr "Masquage-auto/Petits appareils"
 
 #: src/labels.h:351
 msgid "Automatically hide tables on small screen devices"
-msgstr ""
-"Masquer automatiquement les tableaux sur les appareils avec un petit écran"
+msgstr "Masquer automatiquement les tableaux sur les appareils avec un petit écran"
 
 #: src/labels.h:353
 msgid "Toggle Panel"
@@ -693,8 +687,7 @@ msgstr "100 - Continue: Le serveur a reçu la partie initiale de la requête"
 
 #: src/labels.h:406
 msgid "101 - Switching Protocols: Client asked to switch protocols"
-msgstr ""
-"101 - Echange de Protocoles: Le client a demandé à changer de protocole"
+msgstr "101 - Echange de Protocoles: Le client a demandé à changer de protocole"
 
 #: src/labels.h:408
 msgid "200 - OK: The request sent by the client was successful"
@@ -740,8 +733,7 @@ msgstr "300 - Choix multiples: Options multiples pour la ressource"
 
 #: src/labels.h:428
 msgid "301 - Moved Permanently: Resource has permanently moved"
-msgstr ""
-"301 - Déplacement permanent: La ressource a été déplacée de façon permanente"
+msgstr "301 - Déplacement permanent: La ressource a été déplacée de façon permanente"
 
 #: src/labels.h:430
 msgid "302 - Moved Temporarily (redirect)"
@@ -774,8 +766,7 @@ msgstr "400 - Mauvaise requête: Syntaxe de la requête invalide"
 
 #: src/labels.h:444
 msgid "401 - Unauthorized: Request needs user authentication"
-msgstr ""
-"401 - Non autorisé: La requête nécessite une authentification utilisateur"
+msgstr "401 - Non autorisé: La requête nécessite une authentification utilisateur"
 
 #: src/labels.h:446
 msgid "402 - Payment Required"
@@ -803,8 +794,7 @@ msgstr "407 - Authentification au proxy requise"
 
 #: src/labels.h:458
 msgid "408 - Request Timeout: Server timed out waiting for the request"
-msgstr ""
-"408 - Requête expirée: Délai d'attente du serveur dépassé pour la requête"
+msgstr "408 - Requête expirée: Délai d'attente du serveur dépassé pour la requête"
 
 #: src/labels.h:460
 msgid "409 - Conflict: Conflict in the request"
@@ -836,8 +826,7 @@ msgstr "415 - Type de média non supporté : Type de media non pris en charge"
 
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
-msgstr ""
-"416 - Plage de requête non satisfaisante: ne peut pas fournir cette partie"
+msgstr "416 - Plage de requête non satisfaisante: ne peut pas fournir cette partie"
 
 #: src/labels.h:476
 msgid "417 - Expectation Failed"
@@ -957,31 +946,3 @@ msgstr "523 - CloudFlare - L'Origin n'est pas joignable"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - Un dépassement du délai s'est produit"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Temps Init. Proc."
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr ""
-#~ "Construit par défaut en mémoire avec une base de données de la table de "
-#~ "hachage"
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "Construit sur le disque en arbre B+ en utilisant Tokyo Cabinet."
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr ""
-#~ "Construit en mémoire avec une base de données de la table de hachage en "
-#~ "utilisant Tokyo Cabinet"
-
-#~ msgid "Bandwidth"
-#~ msgstr "Bande passante"
-
-#~ msgid "Unique Files"
-#~ msgstr "Fichiers uniques"
-
-#~ msgid "Unique 404"
-#~ msgstr "Unique 404"
-
-#~ msgid " - Including spiders"
-#~ msgstr "- Inclus robots d'indexation"

--- a/po/goaccess.pot
+++ b/po/goaccess.pot
@@ -1,9 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# This file is distributed under the same license as the goaccess package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.7\n"
@@ -14,7 +8,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=iso-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/labels.h:40

--- a/po/it.po
+++ b/po/it.po
@@ -1,8 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: Goaccess\n"
@@ -13,7 +8,7 @@ msgstr ""
 "Language-Team: \n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
 
@@ -286,8 +281,7 @@ msgstr "Hostname e IP dei Visitatori"
 
 #: src/labels.h:159
 msgid "Top visitor hosts sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Principali host dei visitatori ordinati per accessi [, avgts, cumts, maxts]"
+msgstr "Principali host dei visitatori ordinati per accessi [, avgts, cumts, maxts]"
 
 #: src/labels.h:161
 msgid "Hosts"
@@ -299,8 +293,7 @@ msgstr "Sistemi Operativi"
 
 #: src/labels.h:166
 msgid "Top Operating Systems sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Principali Sistemi Operativi ordinati per accessi [, avgts, cumts, maxts]"
+msgstr "Principali Sistemi Operativi ordinati per accessi [, avgts, cumts, maxts]"
 
 #: src/labels.h:168
 msgid "OS"
@@ -322,8 +315,7 @@ msgstr "URL Referrer"
 #: src/labels.h:180
 #, fuzzy
 msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Principali Referrer Richiesti ordinati per accessi [, avgts, cumts, maxts]"
+msgstr "Principali Referrer Richiesti ordinati per accessi [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
@@ -368,8 +360,7 @@ msgstr "Codici Di Stato HTTP"
 
 #: src/labels.h:215
 msgid "Top HTTP Status Codes sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Principali Codici Di Stato HTTP ordinati per accessi [, avgts, cumts, maxts]"
+msgstr "Principali Codici Di Stato HTTP ordinati per accessi [, avgts, cumts, maxts]"
 
 #: src/labels.h:217
 msgid "Status Codes"
@@ -692,13 +683,11 @@ msgstr "5xx Errori Server"
 
 #: src/labels.h:404
 msgid "100 - Continue: Server received the initial part of the request"
-msgstr ""
-"100 - Continue: Il server ha ricevuto la parte iniziale della richiesta"
+msgstr "100 - Continue: Il server ha ricevuto la parte iniziale della richiesta"
 
 #: src/labels.h:406
 msgid "101 - Switching Protocols: Client asked to switch protocols"
-msgstr ""
-"101 - Switching Protocols: Il client ha richiesto di cambiare protocolli"
+msgstr "101 - Switching Protocols: Il client ha richiesto di cambiare protocolli"
 
 #: src/labels.h:408
 msgid "200 - OK: The request sent by the client was successful"
@@ -836,8 +825,7 @@ msgstr "415 - Unsupported Media Type: Tipo media non supportato"
 
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
-msgstr ""
-"416 - Requested Range Not Satisfiable: Impossibile fornire quel frammento"
+msgstr "416 - Requested Range Not Satisfiable: Impossibile fornire quel frammento"
 
 #: src/labels.h:476
 msgid "417 - Expectation Failed"
@@ -866,8 +854,7 @@ msgstr "424 - Failed Dependency: WebDAV"
 
 #: src/labels.h:488
 msgid "426 - Upgrade Required: Client should switch to a different protocol"
-msgstr ""
-"426 - Upgrade Required: Il cliente dovrebbe utilizzare un protocollo diverso"
+msgstr "426 - Upgrade Required: Il cliente dovrebbe utilizzare un protocollo diverso"
 
 #: src/labels.h:490
 msgid "428 - Precondition Required"
@@ -954,24 +941,3 @@ msgstr "523 - CloudFlare - Origin is unreachable"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - A timeout occurred"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Ora Inizio Proc."
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr "Built using the default in-memory hash database."
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "Built using Tokyo Cabinet on-disk B+ Tree."
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr "Built using Tokyo Cabinet in-memory hash database."
-
-#~ msgid "Bandwidth"
-#~ msgstr "Larghezza Di Banda"
-
-#~ msgid "Unique Files"
-#~ msgstr "File Unici"
-
-#~ msgid "Unique 404"
-#~ msgstr "404 Unico"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,8 +1,3 @@
-# Japanese translations for goaccess package.
-# Copyright (C) 2018 Free Software Foundation, Inc.
-# This file is distributed under the same license as the goaccess package.
-# Kamino, 2020
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.3\n"
@@ -13,7 +8,7 @@ msgstr ""
 "Language-Team: Japanese\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
@@ -208,9 +203,7 @@ msgstr "一日あたりのユニークユーザー数（クローラも含める
 
 #: src/labels.h:103
 msgid "Hits having the same IP, date and agent are a unique visit."
-msgstr ""
-"IPアドレス、日付、ユーザーエージェントが全て同一だった場合、ユニークユーザー"
-"として扱われます。"
+msgstr "IPアドレス、日付、ユーザーエージェントが全て同一だった場合、ユニークユーザーとして扱われます。"
 
 #: src/labels.h:108
 msgid "Requested Files (URLs)"
@@ -230,8 +223,7 @@ msgstr "静的ファイルリクエスト数"
 
 #: src/labels.h:117
 msgid "Top static requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"静的ファイルリクエスト順にソート [平均処理時間、合計処理時間、最大処理時間]"
+msgstr "静的ファイルリクエスト順にソート [平均処理時間、合計処理時間、最大処理時間]"
 
 #: src/labels.h:122
 msgid "Time Distribution"
@@ -239,8 +231,7 @@ msgstr "時間分布"
 
 #: src/labels.h:124
 msgid "Data sorted by hour [, avgts, cumts, maxts]"
-msgstr ""
-"リクエストされた時刻順にソート [平均処理時間、合計処理時間、最大処理時間]"
+msgstr "リクエストされた時刻順にソート [平均処理時間、合計処理時間、最大処理時間]"
 
 #: src/labels.h:126
 msgid "Time"
@@ -363,8 +354,7 @@ msgstr "HTTPステータスコード"
 
 #: src/labels.h:215
 msgid "Top HTTP Status Codes sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"HTTPステータスコード順にソート [平均処理時間、合計処理時間、最大処理時間]"
+msgstr "HTTPステータスコード順にソート [平均処理時間、合計処理時間、最大処理時間]"
 
 #: src/labels.h:217
 msgid "Status Codes"
@@ -465,8 +455,7 @@ msgstr ""
 
 #: src/labels.h:287
 msgid "Format Errors - Verify your log/date/time format"
-msgstr ""
-"解析に失敗しました - ログ/日付/時刻のフォーマット設定を確認してください"
+msgstr "解析に失敗しました - ログ/日付/時刻のフォーマット設定を確認してください"
 
 #: src/labels.h:289
 msgid "No date format was found on your conf file."
@@ -692,8 +681,7 @@ msgstr "100 - 継続: リクエストヘッダーを受理しました"
 
 #: src/labels.h:406
 msgid "101 - Switching Protocols: Client asked to switch protocols"
-msgstr ""
-"101 - プロトコル変更: HTTPヘッダーでリクエストされたプロトコルに切り替えます"
+msgstr "101 - プロトコル変更: HTTPヘッダーでリクエストされたプロトコルに切り替えます"
 
 #: src/labels.h:408
 msgid "200 - OK: The request sent by the client was successful"
@@ -709,21 +697,15 @@ msgstr "202 - 受理: リクエストを受け取ったが処理されていま�
 
 #: src/labels.h:414
 msgid "203 - Non-authoritative Information: Response from a third party"
-msgstr ""
-"203 - 認証されていない情報: リクエストを正常に処理しましたが、返される情報は"
-"別の送信元から来る可能性があります"
+msgstr "203 - 認証されていない情報: リクエストを正常に処理しましたが、返される情報は別の送信元から来る可能性があります"
 
 #: src/labels.h:416
 msgid "204 - No Content: Request did not return any content"
-msgstr ""
-"204 - コンテンツ無し: リクエストを正常に処理しましたが、返すべき情報がありま"
-"せん"
+msgstr "204 - コンテンツ無し: リクエストを正常に処理しましたが、返すべき情報がありません"
 
 #: src/labels.h:418
 msgid "205 - Reset Content: Server asked the client to reset the document"
-msgstr ""
-"205 - リセット要求: クライアントに対してドキュメントビューのリセットを行うよ"
-"う要求しました"
+msgstr "205 - リセット要求: クライアントに対してドキュメントビューのリセットを行うよう要求しました"
 
 #: src/labels.h:420
 msgid "206 - Partial Content: The partial GET has been successful"
@@ -751,8 +733,7 @@ msgstr "302 - 一時的な移動: リクエストされたリソースは一時�
 
 #: src/labels.h:432
 msgid "303 - See Other Document: The response is at a different URI"
-msgstr ""
-"303 - 別コンテンツ: リクエストされたリソースは別のURLで提供されています"
+msgstr "303 - 別コンテンツ: リクエストされたリソースは別のURLで提供されています"
 
 #: src/labels.h:434
 msgid "304 - Not Modified: Resource has not been modified"
@@ -760,8 +741,7 @@ msgstr "304 - 更新無し: リクエストされたリソースは更新され�
 
 #: src/labels.h:436
 msgid "305 - Use Proxy: Can only be accessed through the proxy"
-msgstr ""
-"305 - プロキシ使用: リクエストされたリソースはプロキシを使用して取得できます"
+msgstr "305 - プロキシ使用: リクエストされたリソースはプロキシを使用して取得できます"
 
 #: src/labels.h:438
 msgid "307 - Temporary Redirect: Resource temporarily moved"
@@ -793,9 +773,7 @@ msgstr "404 - リソース不明: リクエストされたリソースは存在�
 
 #: src/labels.h:452
 msgid "405 - Method Not Allowed: Request method not supported"
-msgstr ""
-"405 - 許可されていない: リクエストされたメソッドでのアクセスは禁止されていま"
-"す"
+msgstr "405 - 許可されていない: リクエストされたメソッドでのアクセスは禁止されています"
 
 #: src/labels.h:454
 msgid "406 - Not Acceptable"
@@ -839,9 +817,7 @@ msgstr "415 - サポートされていないメディアタイプ"
 
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
-msgstr ""
-"416 - リクエストされたContent-Lengthヘッダーの範囲がリソースより超過していま"
-"す"
+msgstr "416 - リクエストされたContent-Lengthヘッダーの範囲がリソースより超過しています"
 
 #: src/labels.h:476
 msgid "417 - Expectation Failed"
@@ -870,8 +846,7 @@ msgstr "424 - (WebDAV拡張) 依存関係でエラーが発生しました"
 
 #: src/labels.h:488
 msgid "426 - Upgrade Required: Client should switch to a different protocol"
-msgstr ""
-"426 - アップグレードが必要: プロトコルが古すぎてリクエストを処理できません"
+msgstr "426 - アップグレードが必要: プロトコルが古すぎてリクエストを処理できません"
 
 #: src/labels.h:490
 msgid "428 - Precondition Required"
@@ -911,8 +886,7 @@ msgstr "497 - (nginx) HTTPリクエストをHTTPSポートに送信しました"
 
 #: src/labels.h:508
 msgid "499 - (Nginx) Connection closed by client while processing request"
-msgstr ""
-"499 - (nginx) リクエストを処理中にクライアントによって接続を閉じられました"
+msgstr "499 - (nginx) リクエストを処理中にクライアントによって接続を閉じられました"
 
 #: src/labels.h:510
 msgid "500 - Internal Server Error"
@@ -924,8 +898,7 @@ msgstr "501 - 実装されていません"
 
 #: src/labels.h:514
 msgid "502 - Bad Gateway: Received an invalid response from the upstream"
-msgstr ""
-"502 - 不正なゲートウェイ: 上位サーバーから不正なレスポンスを受信しました"
+msgstr "502 - 不正なゲートウェイ: 上位サーバーから不正なレスポンスを受信しました"
 
 #: src/labels.h:516
 msgid "503 - Service Unavailable: The server is currently unavailable"
@@ -958,6 +931,3 @@ msgstr "523 - CloudFlare - Originに到達できません"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - タイムアウトが発生しました"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "解析にかかった時間"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1,8 +1,3 @@
-# Korean translations for goaccess package.
-# Copyright (C) 2022 Free Software Foundation, Inc.
-# This file is distributed under the same license as the goaccess package.
-# David 창모 Yang <dcyang@users.noreply.github.com>, 2022.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.6.3\n"
@@ -13,7 +8,7 @@ msgstr ""
 "Language-Team: Korean <dcyang@users.noreply.github.com>\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "X-Generator: Gtranslator 40.0\n"
@@ -217,9 +212,7 @@ msgstr "요청된 파일 (URL)"
 
 #: src/labels.h:110
 msgid "Top requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"방문 수 순으로 정렬한 요청 수 [, 평균 처리시간, 누적 처리시간, 최대 처리시"
-"간, 접속 방법, 프로토콜]"
+msgstr "방문 수 순으로 정렬한 요청 수 [, 평균 처리시간, 누적 처리시간, 최대 처리시간, 접속 방법, 프로토콜]"
 
 #: src/labels.h:112
 msgid "Requests"
@@ -231,9 +224,7 @@ msgstr "정적 파일 요청 수"
 
 #: src/labels.h:117
 msgid "Top static requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"방문 수 순으로 정렬한 정적 파일 요청 수 [, 평균 처리시간, 누적 처리시간, 최"
-"대 처리시간, 접속 방법, 프로토콜]"
+msgstr "방문 수 순으로 정렬한 정적 파일 요청 수 [, 평균 처리시간, 누적 처리시간, 최대 처리시간, 접속 방법, 프로토콜]"
 
 #: src/labels.h:122
 msgid "Time Distribution"
@@ -253,8 +244,7 @@ msgstr "가상 호스트"
 
 #: src/labels.h:131 src/labels.h:138 src/labels.h:145
 msgid "Data sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 데이터 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
+msgstr "방문 수로 정렬한 데이터 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:136
 msgid "Remote User (HTTP authentication)"
@@ -278,9 +268,7 @@ msgstr "찾을 수 없는 URL (404)"
 
 #: src/labels.h:152
 msgid "Top not found URLs sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"방문 수로 정렬한 찾을 수 없는 URL [, 평균 처리시간, 누적 처리시간, 최대 처리"
-"시간, 접속 방법, 프로토콜]"
+msgstr "방문 수로 정렬한 찾을 수 없는 URL [, 평균 처리시간, 누적 처리시간, 최대 처리시간, 접속 방법, 프로토콜]"
 
 #: src/labels.h:157
 msgid "Visitor Hostnames and IPs"
@@ -288,9 +276,7 @@ msgstr "방문자 호스트명 및 IP"
 
 #: src/labels.h:159
 msgid "Top visitor hosts sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 방문자 호스트 [, 평균 처리시간, 누적 처리시간, 최대 처리시"
-"간]"
+msgstr "방문 수로 정렬한 방문자 호스트 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:161
 msgid "Hosts"
@@ -302,8 +288,7 @@ msgstr "운영체제"
 
 #: src/labels.h:166
 msgid "Top Operating Systems sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 운영체제 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
+msgstr "방문 수로 정렬한 운영체제 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:168
 msgid "OS"
@@ -315,8 +300,7 @@ msgstr "브라우저"
 
 #: src/labels.h:173
 msgid "Top Browsers sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 브라우저 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
+msgstr "방문 수로 정렬한 브라우저 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:178
 #, fuzzy
@@ -326,8 +310,7 @@ msgstr "참조자 URL"
 #: src/labels.h:180
 #, fuzzy
 msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 요청 참조자 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
+msgstr "방문 수로 정렬한 요청 참조자 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:182
 #, fuzzy
@@ -340,8 +323,7 @@ msgstr "출발 사이트"
 
 #: src/labels.h:187
 msgid "Top Referring Sites sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 출발 사이트 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
+msgstr "방문 수로 정렬한 출발 사이트 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:192
 msgid "Keyphrases from Google's search engine"
@@ -349,8 +331,7 @@ msgstr "구글로 검색된 관건문구"
 
 #: src/labels.h:194
 msgid "Top Keyphrases sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 관건문구 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
+msgstr "방문 수로 정렬한 관건문구 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:196
 msgid "Keyphrases"
@@ -362,9 +343,7 @@ msgstr "지리적 위치"
 
 #: src/labels.h:201
 msgid "Continent > Country sorted by unique hits [, avgts, cumts, maxts]"
-msgstr ""
-"순 방문 수로 정렬한 대륙 > 국가 [, 평균 처리시간, 누적 처리시간, 최대 처리시"
-"간]"
+msgstr "순 방문 수로 정렬한 대륙 > 국가 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:208
 msgid "Autonomous System Numbers/Organizations (ASNs)"
@@ -376,9 +355,7 @@ msgstr "HTTP 상태 코드"
 
 #: src/labels.h:215
 msgid "Top HTTP Status Codes sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"방문 수로 정렬한 HTTP 상태 코드 [, 평균 처리시간, 누적 처리시간, 최대 처리시"
-"간]"
+msgstr "방문 수로 정렬한 HTTP 상태 코드 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:217
 msgid "Status Codes"
@@ -701,8 +678,7 @@ msgstr "5xx 서버 오류"
 
 #: src/labels.h:404
 msgid "100 - Continue: Server received the initial part of the request"
-msgstr ""
-"100 - 계속: 서버는 요청의 첫 번째 부분을 받았으며 나머지를 기다리고 있음"
+msgstr "100 - 계속: 서버는 요청의 첫 번째 부분을 받았으며 나머지를 기다리고 있음"
 
 #: src/labels.h:406
 msgid "101 - Switching Protocols: Client asked to switch protocols"
@@ -842,8 +818,7 @@ msgstr "415 - 지원되지 않는 미디어 유형: 미디어 유형이 지원�
 
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
-msgstr ""
-"416 - 처리할 수 없는 요청범위: 서버가 제공할 수 있는 범위를 넘어선 요청"
+msgstr "416 - 처리할 수 없는 요청범위: 서버가 제공할 수 있는 범위를 넘어선 요청"
 
 #: src/labels.h:476
 msgid "417 - Expectation Failed"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,8 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: Goaccess\n"
@@ -13,7 +8,7 @@ msgstr ""
 "Language-Team: \n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
 
@@ -216,8 +211,7 @@ msgstr "Requisições"
 
 #: src/labels.h:110
 msgid "Top requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"Requisições ordenadas por requisições [, avgts, cumts, maxts, mthd, proto]"
+msgstr "Requisições ordenadas por requisições [, avgts, cumts, maxts, mthd, proto]"
 
 #: src/labels.h:112
 msgid "Requests"
@@ -276,8 +270,8 @@ msgstr "URLs Não Encontradas (404)"
 #: src/labels.h:152
 msgid "Top not found URLs sorted by hits [, avgts, cumts, maxts, mthd, proto]"
 msgstr ""
-"URLs não encontradas ordenadas por requisições [, avgts, cumts, maxts, mthd, "
-"proto]"
+"URLs não encontradas ordenadas por requisições [, avgts, cumts, maxts, "
+"mthd, proto]"
 
 #: src/labels.h:157
 msgid "Visitor Hostnames and IPs"
@@ -297,8 +291,7 @@ msgstr "Sistemas Operacionais"
 
 #: src/labels.h:166
 msgid "Top Operating Systems sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Sistemas Operacionais ordenados por requisições [, avgts, cumts, maxts]"
+msgstr "Sistemas Operacionais ordenados por requisições [, avgts, cumts, maxts]"
 
 #: src/labels.h:168
 msgid "OS"
@@ -320,8 +313,7 @@ msgstr "URLs Referenciadas"
 #: src/labels.h:180
 #, fuzzy
 msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Requisições referenciadas ordenadas por requisições [, avgts, cumts, maxts]"
+msgstr "Requisições referenciadas ordenadas por requisições [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
@@ -342,8 +334,7 @@ msgstr "Mecanismo de pesquisa do Google"
 
 #: src/labels.h:194
 msgid "Top Keyphrases sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Frases-chave de busca ordenadas por requisições [, avgts, cumts, maxts]"
+msgstr "Frases-chave de busca ordenadas por requisições [, avgts, cumts, maxts]"
 
 #: src/labels.h:196
 msgid "Keyphrases"
@@ -355,8 +346,7 @@ msgstr "Geo Localização"
 
 #: src/labels.h:201
 msgid "Continent > Country sorted by unique hits [, avgts, cumts, maxts]"
-msgstr ""
-"Continente/Pais ordenado por requisições únicas [, avgts, cumts, maxts]"
+msgstr "Continente/Pais ordenado por requisições únicas [, avgts, cumts, maxts]"
 
 #: src/labels.h:208
 msgid "Autonomous System Numbers/Organizations (ASNs)"
@@ -368,8 +358,7 @@ msgstr "Codigos de Status HTTP"
 
 #: src/labels.h:215
 msgid "Top HTTP Status Codes sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Codigos de Status HTTP ordenados por requisições [, avgts, cumts, maxts]"
+msgstr "Codigos de Status HTTP ordenados por requisições [, avgts, cumts, maxts]"
 
 #: src/labels.h:217
 msgid "Status Codes"
@@ -822,8 +811,7 @@ msgstr "411 - Comprimento Necessário: Comprimento de conteúdo inválido"
 
 #: src/labels.h:466
 msgid "412 - Precondition Failed: Server does not meet preconditions"
-msgstr ""
-"412 - Falha na Pré-Condição: O servidor não atende às condições prévias"
+msgstr "412 - Falha na Pré-Condição: O servidor não atende às condições prévias"
 
 #: src/labels.h:468
 msgid "413 - Payload Too Large"
@@ -840,8 +828,8 @@ msgstr "415 - Tipo de Mídia Sem Suporte: Tipo de mídia não é suportado"
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
 msgstr ""
-"416 - Intervalo da Requisição Não Satisfatório: Não é possível fornecer essa "
-"parte"
+"416 - Intervalo da Requisição Não Satisfatório: Não é possível fornecer "
+"essa parte"
 
 #: src/labels.h:476
 msgid "417 - Expectation Failed"
@@ -880,8 +868,7 @@ msgstr "428 - Pré-Requisito Obrigatório"
 
 #: src/labels.h:492
 msgid "429 - Too Many Requests: The user has sent too many requests"
-msgstr ""
-"429 - Requisições Demasiadas: O utilizador enviou requisições demasiadamente"
+msgstr "429 - Requisições Demasiadas: O utilizador enviou requisições demasiadamente"
 
 #: src/labels.h:494
 #, fuzzy
@@ -961,15 +948,3 @@ msgstr "523 - CloudFlare - A origem está inacessível"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - Ocorreu tempo limite"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Hora Inicio Proc."
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr "Construído usando base de datos hash por defecto en-memoria"
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "Construído usando Tokyo Cabinet on-disk B+ Tree."
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr "Construído usando Tokyo Cabinet in-memory hash database."

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,8 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# This file is distributed under the same license as the goaccess package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.5.6\n"
@@ -13,11 +8,11 @@ msgstr ""
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3.1\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: src/labels.h:40
 msgid "en"
@@ -221,8 +216,8 @@ msgstr "Запрошенные файлы (URL'ы)"
 #: src/labels.h:110
 msgid "Top requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
 msgstr ""
-"Топ запросов, отсортированных по хитам [, ср., общ, макс. вр. обсл., методу, "
-"протоколу]"
+"Топ запросов, отсортированных по хитам [, ср., общ, макс. вр. обсл., "
+"методу, протоколу]"
 
 #: src/labels.h:112
 msgid "Requests"
@@ -353,8 +348,7 @@ msgstr "Ключевые слова из поисковой системы Googl
 
 #: src/labels.h:194
 msgid "Top Keyphrases sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Топ ключевых слов, отсортированных по хитам [, ср., общ, макс. вр. обсл.]"
+msgstr "Топ ключевых слов, отсортированных по хитам [, ср., общ, макс. вр. обсл.]"
 
 #: src/labels.h:196
 msgid "Keyphrases"
@@ -750,8 +744,7 @@ msgstr "208 - Already Reported: WebDAV; RFC 5842"
 
 #: src/labels.h:426
 msgid "300 - Multiple Choices: Multiple options for the resource"
-msgstr ""
-"300 - Multiple Choices: Ресурс имеет несколько вариантов предоставления"
+msgstr "300 - Multiple Choices: Ресурс имеет несколько вариантов предоставления"
 
 #: src/labels.h:428
 msgid "301 - Moved Permanently: Resource has permanently moved"
@@ -929,8 +922,7 @@ msgstr "501 - Not Implemented"
 
 #: src/labels.h:514
 msgid "502 - Bad Gateway: Received an invalid response from the upstream"
-msgstr ""
-"502 - Bad Gateway: Сервер, действующий как шлюз, получил недопустимый ответ"
+msgstr "502 - Bad Gateway: Сервер, действующий как шлюз, получил недопустимый ответ"
 
 #: src/labels.h:516
 msgid "503 - Service Unavailable: The server is currently unavailable"
@@ -938,8 +930,7 @@ msgstr "503 - Service Unavailable: Сервер недоступен"
 
 #: src/labels.h:518
 msgid "504 - Gateway Timeout: The upstream server failed to send request"
-msgstr ""
-"504 - Gateway Timeout: Сервер, действующий как шлюз, не дождался ответа"
+msgstr "504 - Gateway Timeout: Сервер, действующий как шлюз, не дождался ответа"
 
 #: src/labels.h:520
 msgid "505 - HTTP Version Not Supported"
@@ -964,6 +955,3 @@ msgstr "523 - CloudFlare - Origin is unreachable"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - A timeout occurred"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Время обработки лога"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,8 +1,3 @@
-# Swedish translations for goaccess package.
-# Copyright (C) 2019 THE goaccess'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the goaccess package.
-# Anders Johansson, 2019.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.6\n"
@@ -13,7 +8,7 @@ msgstr ""
 "Language-Team: none\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
@@ -216,8 +211,7 @@ msgstr "Begärda filer (URLer)"
 
 #: src/labels.h:110
 msgid "Top requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"Flest förfrågingar sorterade i träffar [, avgts, cumts, maxts, mthd, proto]"
+msgstr "Flest förfrågingar sorterade i träffar [, avgts, cumts, maxts, mthd, proto]"
 
 #: src/labels.h:112
 msgid "Requests"
@@ -229,8 +223,7 @@ msgstr "Statiska förfrågningar"
 
 #: src/labels.h:117
 msgid "Top static requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"Toppförfrågningar sorterade i trufar [, avgts, cumts, maxts, mthd, proto]"
+msgstr "Toppförfrågningar sorterade i trufar [, avgts, cumts, maxts, mthd, proto]"
 
 #: src/labels.h:122
 msgid "Time Distribution"
@@ -318,8 +311,7 @@ msgstr "Hänvisande URL:er"
 #: src/labels.h:180
 #, fuzzy
 msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Flest Hänvisningsförfrågningar sorterade i träffar [, avgts, cumts, maxts]"
+msgstr "Flest Hänvisningsförfrågningar sorterade i träffar [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
@@ -412,8 +404,7 @@ msgstr "Loggformat konfiguration"
 
 #: src/labels.h:247
 msgid "[SPACE] to toggle - [ENTER] to proceed - [q] to quit"
-msgstr ""
-"[SPACE] för att växla - [ENTER] för att fortsätta - [q] för att avsluta"
+msgstr "[SPACE] för att växla - [ENTER] för att fortsätta - [q] för att avsluta"
 
 #: src/labels.h:249
 msgid "Log Format - [c] to add/edit format"
@@ -716,8 +707,7 @@ msgstr "204 - Inget innehåll: Förfrågan returnerade inte något innehåll"
 
 #: src/labels.h:418
 msgid "205 - Reset Content: Server asked the client to reset the document"
-msgstr ""
-"205 - Återställ innehåll: Server bad klienten om att återställa dokumentet"
+msgstr "205 - Återställ innehåll: Server bad klienten om att återställa dokumentet"
 
 #: src/labels.h:420
 msgid "206 - Partial Content: The partial GET has been successful"
@@ -816,8 +806,7 @@ msgstr "411 - Krav längd: Ogiltigt innehållslängd"
 
 #: src/labels.h:466
 msgid "412 - Precondition Failed: Server does not meet preconditions"
-msgstr ""
-"412 - Förutsättning misslyckades: Server uppfyller inte förutsättningar"
+msgstr "412 - Förutsättning misslyckades: Server uppfyller inte förutsättningar"
 
 #: src/labels.h:468
 msgid "413 - Payload Too Large"
@@ -833,8 +822,7 @@ msgstr "415 - Medietyp som inte stöds: Medietypen stöds inte"
 
 #: src/labels.h:474
 msgid "416 - Requested Range Not Satisfiable: Cannot supply that portion"
-msgstr ""
-"416 - Begärd räckvidd Ej Tillfredställande: Kan inte leverera den delen"
+msgstr "416 - Begärd räckvidd Ej Tillfredställande: Kan inte leverera den delen"
 
 #: src/labels.h:476
 msgid "417 - Expectation Failed"
@@ -872,7 +860,8 @@ msgstr "428 - Förutsättning krävs"
 #: src/labels.h:492
 msgid "429 - Too Many Requests: The user has sent too many requests"
 msgstr ""
-"429 - För många förfrågningar: Användaren har skickat för många förfrågningar"
+"429 - För många förfrågningar: Användaren har skickat för många "
+"förfrågningar"
 
 #: src/labels.h:494
 msgid "431 - Request Header Fields Too Large"
@@ -951,15 +940,3 @@ msgstr "523 - CloudFlare - Ursprung är oåtkomligt"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - En timeout inträffade"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Init. proc. Tid"
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr "Byggd med standard in-memory hash databas"
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "Byggd med Tokyo Cabinet on-disk B+ Tree."
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr "Byggd med Tokyo Cabinet in-memory hash databas."

--- a/po/uk.po
+++ b/po/uk.po
@@ -1,8 +1,3 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
-# This file is distributed under the same license as the goaccess package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.5.6\n"
@@ -13,11 +8,11 @@ msgstr ""
 "Language-Team: \n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3.1\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: src/labels.h:40
 msgid "en"
@@ -318,8 +313,7 @@ msgstr "Браузери"
 
 #: src/labels.h:173
 msgid "Top Browsers sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Топ браузерів, відсортованих за хітами [, сер., заг., макс. часом обсл.]"
+msgstr "Топ браузерів, відсортованих за хітами [, сер., заг., макс. часом обсл.]"
 
 #: src/labels.h:178
 #, fuzzy
@@ -354,8 +348,7 @@ msgstr "Ключові слова з пошукової системи Google"
 
 #: src/labels.h:194
 msgid "Top Keyphrases sorted by hits [, avgts, cumts, maxts]"
-msgstr ""
-"Том ключових слів, відсортованих за хітами [, сер., заг., макс. часом обсл.]"
+msgstr "Том ключових слів, відсортованих за хітами [, сер., заг., макс. часом обсл.]"
 
 #: src/labels.h:196
 msgid "Keyphrases"
@@ -368,8 +361,8 @@ msgstr "Географічне розташування"
 #: src/labels.h:201
 msgid "Continent > Country sorted by unique hits [, avgts, cumts, maxts]"
 msgstr ""
-"Континенти > країни, відсортовані за унікальними хітами [, сер., заг., макс. "
-"часом обсл.]"
+"Континенти > країни, відсортовані за унікальними хітами [, сер., заг., "
+"макс. часом обсл.]"
 
 #: src/labels.h:208
 msgid "Autonomous System Numbers/Organizations (ASNs)"
@@ -929,8 +922,7 @@ msgstr "501 - Not Implemented"
 
 #: src/labels.h:514
 msgid "502 - Bad Gateway: Received an invalid response from the upstream"
-msgstr ""
-"502 - Bad Gateway: Сервер, який діє як шлюз, отримав недійсну відповідь"
+msgstr "502 - Bad Gateway: Сервер, який діє як шлюз, отримав недійсну відповідь"
 
 #: src/labels.h:516
 msgid "503 - Service Unavailable: The server is currently unavailable"
@@ -938,8 +930,7 @@ msgstr "503 - Service Unavailable: Сервер недоступний"
 
 #: src/labels.h:518
 msgid "504 - Gateway Timeout: The upstream server failed to send request"
-msgstr ""
-"504 - Gateway Timeout: Сервер, який діє як шлюз, не дочекався відповіді"
+msgstr "504 - Gateway Timeout: Сервер, який діє як шлюз, не дочекався відповіді"
 
 #: src/labels.h:520
 msgid "505 - HTTP Version Not Supported"
@@ -964,6 +955,3 @@ msgstr "523 - CloudFlare - Origin is unreachable"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - A timeout occurred"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "Час обробки лога"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,6 +1,3 @@
-# This file is distributed under the same license as the goaccess package.
-# Ai, 2018.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: goaccess 1.5.6\n"
@@ -11,7 +8,7 @@ msgstr ""
 "Language-Team: Ai\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Gtranslator 2.91.7\n"
@@ -215,8 +212,7 @@ msgstr "请求的文件"
 
 #: src/labels.h:110
 msgid "Top requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"请求排序按 [点击量, 平均响应时, 总共响应时, 最高响应时, 请求方法, 协议]"
+msgstr "请求排序按 [点击量, 平均响应时, 总共响应时, 最高响应时, 请求方法, 协议]"
 
 #: src/labels.h:112
 msgid "Requests"
@@ -228,8 +224,7 @@ msgstr "静态请求"
 
 #: src/labels.h:117
 msgid "Top static requests sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"静态请求排序按 [点击量, 平均响应时, 总共响应时, 最高响应时, 请求方法, 协议]"
+msgstr "静态请求排序按 [点击量, 平均响应时, 总共响应时, 最高响应时, 请求方法, 协议]"
 
 #: src/labels.h:122
 msgid "Time Distribution"
@@ -273,9 +268,7 @@ msgstr "未找到的URLs"
 
 #: src/labels.h:152
 msgid "Top not found URLs sorted by hits [, avgts, cumts, maxts, mthd, proto]"
-msgstr ""
-"未找到的URLs排序按 [点击量, 平均响应时, 总共响应时, 最高响应时, 请求方法, 协"
-"议]"
+msgstr "未找到的URLs排序按 [点击量, 平均响应时, 总共响应时, 最高响应时, 请求方法, 协议]"
 
 #: src/labels.h:157
 msgid "Visitor Hostnames and IPs"
@@ -941,27 +934,3 @@ msgstr "523 - CloudFlare - 服务器无法访问"
 #: src/labels.h:530
 msgid "524 - CloudFlare - A timeout occurred"
 msgstr "524 - CloudFlare - 服务器响应超时"
-
-#~ msgid "Init. Proc. Time"
-#~ msgstr "第一次处理耗时"
-
-#~ msgid "Built using the default in-memory hash database."
-#~ msgstr "使用默认的在内存中的哈希表来构建"
-
-#~ msgid "Built using Tokyo Cabinet on-disk B+ Tree."
-#~ msgstr "使用Tokyo Cabinet在磁盘中的B+树来构建"
-
-#~ msgid "Built using Tokyo Cabinet in-memory hash database."
-#~ msgstr "使用Tokyo Cabinet的内存中的哈希表来构建"
-
-#~ msgid "Bandwidth"
-#~ msgstr "带宽"
-
-#~ msgid "Unique Files"
-#~ msgstr "唯一的文件"
-
-#~ msgid "Unique 404"
-#~ msgstr "唯一的404"
-
-#~ msgid " - Including spiders"
-#~ msgstr "- 包括网络机器人"


### PR DESCRIPTION
Hi,

Changes

- added an inlang.config.js file to the root of the repo
- updated and fix German translations

I saw your german translation was broken. To make it easier for me to contribute to your translation, I added the tool [inlang/inlang](https://github.com/inlang/inlang). I am opening this PR as a draft to discuss the tool. Maintainers or contributors would have no overhead as inlang is built on git. No accounts (login with GitHub), no sync, and no pipelines are required. Contributions open a PR.

Would an UI over the translations in this repo be of benefit to the goaccess community?

You can try it out on my fork and post your feedback under this draft.
https://inlang.com/editor/github.com/jannesblobel/goaccess


The PR is theoretically ready for review.