### PR TITLE
Fix null pointer exception on FreeBSD (fixes #2476)

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -134,7 +134,7 @@ set_glog (Logs * logs, const char *filename) {
   GLog *tmp = NULL, *glog = NULL;
   int newlen = 0;
   char const *err;
-  char *fvh = NULL, *fn = (char *) filename;
+  char *fvh = NULL, *fn = NULL;
 
   if (logs->size - 1 < logs->idx) {
     newlen = logs->size + 1;
@@ -147,6 +147,7 @@ set_glog (Logs * logs, const char *filename) {
     logs->size = newlen;
   }
 
+  fn = xstrdup (filename);  /* ensure fn is a string */
   glog = logs->glog;
   glog[logs->idx].errors = xcalloc (MAX_LOG_ERRORS, sizeof (char *));
   glog[logs->idx].filename = xstrdup (fn);
@@ -161,6 +162,7 @@ set_glog (Logs * logs, const char *filename) {
   logs->processed = &(glog[logs->idx].processed);
   logs->filename = glog[logs->idx].filename;
   logs->idx++;
+  free (fn);
 
   return 0;
 }


### PR DESCRIPTION
On FreeBSD, goaccess dumps core when reading from STDIN.

FreeBSD's basename(3) behaves a little different from the rest of the world. Rather than sometimes returning a pointer to a new allocation, it always returns a pointer into the buffer itself.

When basename() gets a string, including an empty string, it behaves as expected. But if it's given a null pointer, it returns another null pointer rather than a pointer to a newly-allocated empty string. This makes it thread-safe, but (as usual for FreeBSD) assumes that the rest of the world enjoys FreeBSD's quirky null pointer exceptions.

When reading from STDIN, the filenames vector is empty, so set_glog's filename arg is empty. Calling basename on it makes a null pointer, and subsequent use causes a segfault.

Calling xstrdup on the filename is a pointless but trivial duplication for the non-BSD world, but guarantees a string of some sort for FreeBSD.