### PR TITLE
Fix spelling errors as reported by the spellcheck action

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -174,7 +174,7 @@ Changes to GoAccess 1.5 - Wednesday, May 26, 2021
   - Fixed memory leak when a JSON value contained an empty string (e.g.,
     JSON/CADDY format).
   - Fixed possible buffer overflow on a WS packet coming from the browser.
-  - Refactored a substancial part of the storage codebase for upcoming
+  - Refactored a substantial part of the storage codebase for upcoming
     filtering/search capabilities (issue #117).
   - Refactored DB storage to minimize memory consumption up to '35%'.
   - Updated default 'AWS Elastic Load Balancing' log format.
@@ -262,7 +262,7 @@ Changes to GoAccess 1.4.2 - Monday, November 16, 2020
 
 Changes to GoAccess 1.4.1 - Monday, November 09, 2020
 
-  - Added addtional browsers and bots to the main list.
+  - Added additional browsers and bots to the main list.
   - Added 'Android 11' to the list of OSs.
   - Added 'macOS 11.0 Big Sur' to the list of OSs.
   - Added 'average' to each panel overall metrics.
@@ -394,7 +394,7 @@ Changes to GoAccess 1.3 - Friday, November 23, 2018
   - Added French translation (i18n).
   - Added '%h' date specifier to the allowed date character specifiers.
   - Added "HeadlessChrome" to the list of browsers.
-  - Added --hide-referer command line option to hide referers from report.
+  - Added --hide-referer command line option to hide referrers from report.
   - Added HTTP status code 429 (TOO MANY REQUESTS).
   - Added IGNORE_LEVEL_PANEL and IGNORE_LEVEL_REQ definitions.
   - Added Japanese translation (i18n).
@@ -443,7 +443,7 @@ Changes to GoAccess 1.3 - Friday, November 23, 2018
   - Fixed float percent value on JSON/HTML output for locales using decimal comma.
   - Fixed issue where it was not possible to establish a Web Socket connection
     when attempting to parse and extract HTTP method.
-  - Fixed issue where log formats with pipe delimiter were not propely parsed.
+  - Fixed issue where log formats with pipe delimiter were not properly parsed.
   - Fixed memory leak after config file path has been set (housekeeping).
   - Fixed memory leak when adding host to holder introduced in c052d1ea.
   - Fixed possible memory leak when hiding specific referrers.
@@ -796,7 +796,7 @@ Changes to GoAccess 0.9 - Thursday, March 19, 2015
   - Added "visitors" metrics to all panels.
   - Changed AC_PREREQ macro version so it builds on old versions of autoconf.
   - Changed GEOIP database load to GEOIP_MEMORY_CACHE for faster lookups.
-  - Changed maximum number of choices to display per panel to 366 fron 300.
+  - Changed maximum number of choices to display per panel to 366 from 300.
   - Ensure config file is read from home dir if unable to open it from
     %sysconfdir% path.
   - Fixed array overflows when exceeding MAX_* limits on command line options.
@@ -864,7 +864,7 @@ Changes to GoAccess 0.8.1 - Monday, June 16, 2014
     file.
   - Added ability to print backtrace on segmentation fault.
   - Escaped JSON strings correctly according to [RFC4627].
-  - Fixed encoding issue when extracting keyphrases for some HTTP referers.
+  - Fixed encoding issue when extracting keyphrases for some HTTP referrers.
   - Fixed issue where HTML bar graphs were not shown due to numeric locale.
   - Fixed issue with URIs containing "\r?\n" thus breaking the corresponding
     output.

--- a/build-dynamic.sh
+++ b/build-dynamic.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Build dynmic linked binaries on Debian.
+# Build dynamic linked binaries on Debian.
 set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable
 set -o errexit   ## set -e : exit the script if any statement returns a non-true return value
 

--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -209,7 +209,7 @@ no-tab-scroll false
 #
 #no-html-last-updated true
 
-# Ouputs the report date/time data in the given timezone. Note that it
+# Outputs the report date/time data in the given timezone. Note that it
 # uses the canonical timezone name. See --datetime-format in order to
 # properly specify a timezone in the date/time format.
 #

--- a/goaccess.1
+++ b/goaccess.1
@@ -389,14 +389,14 @@ Do not show the last updated field displayed in the HTML generated report.
 Do now show the progress metrics and parsing spinner.
 .TP
 \fB\-\-tz=<timezone>
-Ouputs the report date/time data in the given timezone. Note that it uses the
+Outputs the report date/time data in the given timezone. Note that it uses the
 canonical timezone name. e.g.,
 .I Europe/Berlin
 or
 .I America/Chicago
 or
 .I Africa/Cairo
-If an invalid timezone name is given, the ouput will be in GMT. See
+If an invalid timezone name is given, the output will be in GMT. See
 .I --datetime-format
 in order to properly specify a timezone in the date/time format.
 .SS
@@ -689,7 +689,7 @@ Ignore parsing and displaying the given panel.
   TLS_TYPE
 .TP
 \fB\-\-ignore-referrer=<referrer>
-Ignore referers from being counted. Wildcards allowed. e.g.,
+Ignore referrers from being counted. Wildcards allowed. e.g.,
 .I
 *.domain.com
 .I

--- a/po/de.po
+++ b/po/de.po
@@ -318,18 +318,18 @@ msgstr "Häufigste Browser sortiert nach Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "Verweis-URLs"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "Häufigste ausgehende Verweise sortiert nach Zugriffen [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Verweise"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/es.po
+++ b/po/es.po
@@ -308,17 +308,17 @@ msgstr "Navegadores top ordenados por hits [, avgts, cumts, maxts]"
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "URLs Referidos"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr "Peticiones top de referidos ordenadas por hits [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Referidos"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/fr.po
+++ b/po/fr.po
@@ -308,17 +308,17 @@ msgstr "Top des Navigateurs trié par hits [, avgts, cumts, maxts]"
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "URLs d'origine"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr "Top des URLs d'origine trié par hits [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Origine"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/goaccess.pot
+++ b/po/goaccess.pot
@@ -307,15 +307,15 @@ msgid "Top Browsers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 
 #: src/labels.h:178
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr ""
 
 #: src/labels.h:180
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 
 #: src/labels.h:182
-msgid "Referers"
+msgid "Referrers"
 msgstr ""
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/it.po
+++ b/po/it.po
@@ -311,18 +311,18 @@ msgstr "Principali Browser ordinati per accessi [, avgts, cumts, maxts]"
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "URL Referrer"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "Principali Referrer Richiesti ordinati per accessi [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Referrer"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/ja.po
+++ b/po/ja.po
@@ -307,17 +307,17 @@ msgstr "ブラウザ順にソート [平均処理時間、合計処理時間、�
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "参照元（URL）"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr "送信元アドレス順にソート [平均処理時間、合計処理時間、最大処理時間]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "リファラー数"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/ko.po
+++ b/po/ko.po
@@ -315,18 +315,18 @@ msgstr ""
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "참조자 URL"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "방문 수로 정렬한 요청 참조자 [, 평균 처리시간, 누적 처리시간, 최대 처리시간]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "참조자 수"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -309,18 +309,18 @@ msgstr "Navegadores ordenados por requisições [, avgts, cumts, maxts]"
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "URLs Referenciadas"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "Requisições referenciadas ordenadas por requisições [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Referenciadores"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/ru.po
+++ b/po/ru.po
@@ -317,19 +317,19 @@ msgstr "Топ браузеров, отсортированных по хита�
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "Ссылающиеся страницы"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "Топ ссылающихся страниц, отсортированных по хитам [, ср., общ, макс. вр. "
 "обсл.]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Ссыл. страниц"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/sv.po
+++ b/po/sv.po
@@ -307,18 +307,18 @@ msgstr "Vanligast webbläsare sorterade i träffar [, avgts, cumts, maxts]"
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "Hänvisande URL:er"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "Flest Hänvisningsförfrågningar sorterade i träffar [, avgts, cumts, maxts]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Hänvisningar"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/uk.po
+++ b/po/uk.po
@@ -318,19 +318,19 @@ msgstr ""
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "Сторінки, що посилаються"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr ""
 "Топ сторінок, що посилаються, відсортованих за хітами [, сер., заг., макс. "
 "часом обсл.]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "Посил. сторінок"
 
 #: src/labels.h:185 src/labels.h:189

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -308,17 +308,17 @@ msgstr "浏览器排序按 [点击量, 平均响应时, 总共响应时, 最高�
 
 #: src/labels.h:178
 #, fuzzy
-msgid "Referer URLs"
+msgid "Referrer URLs"
 msgstr "来源地址URLs"
 
 #: src/labels.h:180
 #, fuzzy
-msgid "Top Requested Referers sorted by hits [, avgts, cumts, maxts]"
+msgid "Top Requested Referrers sorted by hits [, avgts, cumts, maxts]"
 msgstr "来源地址排序按 [点击量, 平均响应时, 总共响应时, 最高响应时]"
 
 #: src/labels.h:182
 #, fuzzy
-msgid "Referers"
+msgid "Referrers"
 msgstr "来源地址"
 
 #: src/labels.h:185 src/labels.h:189

--- a/src/geoip2.c
+++ b/src/geoip2.c
@@ -319,7 +319,7 @@ geoip_query_asn_name (MMDB_lookup_result_s res, MMDB_entry_data_s * name) {
 
 /* A wrapper to fetch the looked up result and set the ASN organization & code.
  *
- * If no data is found, "Uknown" is set.
+ * If no data is found, "Unknown" is set.
  * On success, the fetched value is set. */
 void
 geoip_asn (char *host, char *asn) {

--- a/src/labels.h
+++ b/src/labels.h
@@ -180,11 +180,11 @@
   N_("Browsers")
 
 #define REFERRERS_HEAD                 \
-  N_("Referer URLs")
+  N_("Referrer URLs")
 #define REFERRERS_DESC                 \
-  N_("Top Requested Referers sorted by hits [, avgts, cumts, maxts]")
+  N_("Top Requested Referrers sorted by hits [, avgts, cumts, maxts]")
 #define REFERRERS_LABEL                \
-  N_("Referers")
+  N_("Referrers")
 
 #define REFERRING_SITES_HEAD           \
   N_("Referring Sites")

--- a/src/parser.c
+++ b/src/parser.c
@@ -662,11 +662,11 @@ extract_tls_version_cipher (char *tkn, char **cipher, char **tls_version) {
 
   /* ssl context */
   if (!(ctx = SSL_CTX_new (SSLv23_server_method ()))) {
-    LOG_DEBUG (("Unable to create a new SSL_CTX_new to extact TLS."));
+    LOG_DEBUG (("Unable to create a new SSL_CTX_new to extract TLS."));
     goto fail;
   }
   if (!(ssl = SSL_new (ctx))) {
-    LOG_DEBUG (("Unable to create a new instace of SSL_new to extact TLS."));
+    LOG_DEBUG (("Unable to create a new instance of SSL_new to extract TLS."));
     goto fail;
   }
 
@@ -675,12 +675,12 @@ extract_tls_version_cipher (char *tkn, char **cipher, char **tls_version) {
   cipherid[2] = 0;
 
   if (!(c = SSL_CIPHER_find (ssl, cipherid))) {
-    LOG_DEBUG (("Unable to find cipher to extact TLS."));
+    LOG_DEBUG (("Unable to find cipher to extract TLS."));
     goto fail;
   }
 
   if (!(sn = SSL_CIPHER_standard_name (c))) {
-    LOG_DEBUG (("Unable to get cipher standard name to extact TLS."));
+    LOG_DEBUG (("Unable to get cipher standard name to extract TLS."));
     goto fail;
   }
   *cipher = xstrdup (sn);
@@ -1747,7 +1747,7 @@ is_likely_same_log (GLog * glog, const GLastParse * lp) {
 }
 
 /* Determine if we should insert new record or if it's a duplicate record from
- * a previoulsy persisted dataset
+ * a previously persisted dataset
  *
  * Returns 1 if it thinks the record it's being restored from disk
  * Returns 0 if we need to parse the record */

--- a/src/tpl.c
+++ b/src/tpl.c
@@ -1483,7 +1483,7 @@ tpl_peek (int mode, ...) {
     }
 
     if (strncmp (&fmt[first_atom], datapeek_f, datapeek_flen) != 0) {
-      tpl_hook.oops ("TPL_DATAPEEK format mismatches tpl iamge\n");
+      tpl_hook.oops ("TPL_DATAPEEK format mismatches tpl image\n");
       tpl_hook.free (fmt_cpy);
       fmt_cpy = NULL;   /* fail */
       goto fail;


### PR DESCRIPTION
Only comments and display strings are changed here.

Notable here is the correction of referer => referrer.
"Referrer" is the actual spelling; "referer" was a misspelling
that made it into RFC 1945 (see [1]).

It makes the most sense to use "referer" when referring to the
HTTP header, and "referrer" when referring to an actual referring
page.

[1]: https://en.wikipedia.org/wiki/HTTP_referer