### PR TITLE
add translation status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,4 +480,6 @@ discuss and submit code changes.
 
 You can contribute to our translations by editing the .po files direct on Github or using the visual interface [inlang.com](https://inlang.com/editor/github.com/allinurl/goaccess)
 
+[![translation badge](https://inlang.com/badge?url=github.com/allinurl/goaccess)](https://inlang.com/editor/github.com/allinurl/goaccess?ref=badge)
+
 Enjoy!


### PR DESCRIPTION
Hey there, we want you to get more contributors to your repository!
Therefore, I added a badge which lets users contribute to your translations.

The badge endpoint allows you to create a dynamic badge that display real-time data on your project. For instance, you can use it to showcase your project's localization progress or the number of errors/warnings on your Github repository. This means that whenever someone views the badge, they will see the most up-to-date information about your project.

For your project, the badge looks like this:
(this image is already auto generated)

[![translation badge](https://inlang.com/badge?url=github.com/allinurl/goaccess)](https://inlang.com/editor/github.com/allinurl/goaccess?ref=badge)

We would be really happy if you decide to place this into your README to let people contribute to your translations 🥰

– Thank you,
Felix

