### PR TITLE
Macintosh -> macOS

### DIFF
--- a/src/opesys.c
+++ b/src/opesys.c
@@ -78,8 +78,8 @@ static const char *os[][2] = {
   {"iPhone", "iOS"},
   {"CFNetwork", "iOS"},
   {"AppleTV", "iOS"},
-  {"iTunes", "Macintosh"},
-  {"OS X", "Macintosh"},
+  {"iTunes", "macOS"},
+  {"OS X", "macOS"},
   {"Darwin", "Darwin"},
 
   {"Debian", "Linux"},


### PR DESCRIPTION
Referring to macOS (previously OS X, before that Mac OS X) as "Macintosh" is archaic terminology. Fixed that.