### PR TITLE
Add SEARCH method in gstorage.c

### DIFF
--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -100,6 +100,7 @@ const httpmethods http_methods[] = {
   { "TRACE"            , 5  } ,
   { "CONNECT"          , 7  } ,
   { "PATCH"            , 5  } ,
+  { "SEARCH"           , 6  } ,
   /* WebDav */
   { "PROPFIND"         , 8  } ,
   { "PROPPATCH"        , 9  } ,


### PR DESCRIPTION
This pull request addresses Issue #2580, where the GoAccess log parser fails to recognize the 'SEARCH' HTTP method. 