### PR TITLE
Fix heap overflow in set_browser_os()

### DIFF
--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -1021,7 +1021,7 @@ set_browser_os (GLogItem *logitem) {
   logitem->browser = verify_browser (a1, browser_type);
   logitem->browser_type = xstrdup (browser_type);
 
-  if (!memcmp (logitem->browser_type, "Crawlers", 8)) {
+  if (!strncmp (logitem->browser_type, "Crawlers", 9)) {
     logitem->os = xstrdup (logitem->browser);
     logitem->os_type = xstrdup (browser_type);
   } else {


### PR DESCRIPTION
I found this heap-buffer-overflow issue when debugging with ASAN (`-fsanitize=address`). And here is the proposed solution.

<img width="808" alt="image" src="https://github.com/allinurl/goaccess/assets/10102616/3eec5ae1-8977-4b88-a91f-c2fb84e39117">

## Problematic Code
```c
char browser_type[BROWSER_TYPE_LEN] = "";
logitem->browser = verify_browser (ua, browser_type);
logitem->browser_type = xstrdup (browser_type);

if (!memcmp (logitem->browser_type, "Crawlers", 8)) {
    // ...
}
```

## Access Log PoC
```
127.0.0.0 - - [10/Dec/2023:19:30:00 +0800] "GET / HTTP/1.1" 200 1234 "-" "Edge/42"
```

## Reason

Since the User-Agent resolved to `browser_type="Edge"`, it only have 4+1 bytes length. When `memcmp()` for 8 bytes, it will touch the improper memory.

## Proposed Solution 1: Use `strncmp` instead

I think using `strncmp` instead of `memcmp` is the most intuitive way to avoid this problem.
The string length should be 8 char + null = 9 bytes.

```c
if (!strncmp (logitem->browser_type, "Crawlers", 9)) {
    // ...
}
```
## Proposed Solution 2: Compare to local variable instead

If we prefer `memcmp` (not sure about performance between two function), we can use the local variable `browser_type` instead of `logitem->browser_type`.

```diff
-if (!memcmp (logitem->browser_type, "Crawlers", 8)) {
+/* Compare to local variable instead of logitem->browser_type because
+ * xstrdup'd one might have length less than "Crawlers". */
+if (!memcmp (browser_type, "Crawlers", 9)) {
     // ...
 }
```

We can change to solution 2 (with or without comments) if you preferred.