### PR TITLE
handle SIGQUIT as a signal for a graceful shutdown

### DIFF
--- a/src/goaccess.c
+++ b/src/goaccess.c
@@ -1444,6 +1444,8 @@ handle_signal_action (GO_UNUSED int sig_number) {
     fprintf (stderr, "\nSIGINT caught!\n");
   else if (sig_number == SIGTERM)
     fprintf (stderr, "\nSIGTERM caught!\n");
+  else if (sig_number == SIGQUIT)
+    fprintf (stderr, "\nSIGQUIT caught!\n");
   else
     fprintf (stderr, "\nSignal %d caught!\n", sig_number);
   fprintf (stderr, "Closing GoAccess...\n");
@@ -1463,6 +1465,7 @@ setup_thread_signals (void) {
 
   sigaction (SIGINT, &act, NULL);
   sigaction (SIGTERM, &act, NULL);
+  sigaction (SIGQUIT, &act, NULL);
   signal (SIGPIPE, SIG_IGN);
 
   /* Restore old signal mask for the main thread */
@@ -1471,13 +1474,14 @@ setup_thread_signals (void) {
 
 static void
 block_thread_signals (void) {
-  /* Avoid threads catching SIGINT/SIGPIPE/SIGTERM and handle them in
+  /* Avoid threads catching SIGINT/SIGPIPE/SIGTERM/SIGQUIT and handle them in
    * main thread */
   sigset_t sigset;
   sigemptyset (&sigset);
   sigaddset (&sigset, SIGINT);
   sigaddset (&sigset, SIGPIPE);
   sigaddset (&sigset, SIGTERM);
+  sigaddset (&sigset, SIGQUIT);
   pthread_sigmask (SIG_BLOCK, &sigset, &oldset);
 }
 


### PR DESCRIPTION
nginx uses `SIGQUIT` as the signal for a graceful shutdown (https://docs.nginx.com/nginx/admin-guide/basic-functionality/runtime-control/)

some context:
- https://github.com/nginxinc/docker-nginx/issues/377
- https://github.com/nginxinc/docker-nginx/issues/167
- https://trac.nginx.org/nginx/ticket/753

In their Dockerfile they also use 

[`STOPSIGNAL SIGQUIT`](https://github.com/nginxinc/docker-nginx/blob/4bf0763f4977fff7e9648add59e0540088f3ca9f/mainline/debian/Dockerfile#L117)

when also running `goaccess` in the same container via [`dumb-init`](https://github.com/Yelp/dumb-init) or something similar, goaccess will exit non zero upon receiving `SIGQUIT` hence the container shutdown will also have a non zero exit code and tools like docker-compose or an `ansible`-based deployment will treat those as errors and abort the process etc..

This patch simply adds `SIGQUIT` as an allowed signal for a graceful shutdown. `SIGKILL` can still be used for non-graceful shutdowns.

Happy to hear your thoughts on this.