### PR TITLE
doc: add minor documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ build GoAccess from source.
 
 A Docker image has been updated, capable of directing output from an access log. If you only want to output a report, you can pipe a log from the external environment to a Docker-based process:
 
-    cat access.log | docker run --rm -i -e LANG=$LANG allinurl/goaccess -a -o report.html --log-format COMBINED -
+    touch report.html
+    cat access.log | docker run --rm -i -v ./report.html:/report.html -e LANG=$LANG allinurl/goaccess -a -o report.html --log-format COMBINED -
 
 OR real-time
 

--- a/goaccess.1
+++ b/goaccess.1
@@ -599,6 +599,9 @@ octet of IPv4 user IP addresses and the last 80 bits of IPv6 addresses to
 zeros.
 e.g., 192.168.20.100 => 192.168.20.0
 e.g., 2a03:2880:2110:df07:face:b00c::1 => 2a03:2880:2110:df07::
+.IP
+.I Note:
+Note that this deactivates -a.
 .TP
 \fB\-\-chunk-size=<256-32768>
 This determines the number of lines that form a chunk. This parameter

--- a/goaccess.1
+++ b/goaccess.1
@@ -601,7 +601,7 @@ e.g., 192.168.20.100 => 192.168.20.0
 e.g., 2a03:2880:2110:df07:face:b00c::1 => 2a03:2880:2110:df07::
 .IP
 .I Note:
-Note that this deactivates -a.
+This deactivates -a.
 .TP
 \fB\-\-chunk-size=<256-32768>
 This determines the number of lines that form a chunk. This parameter

--- a/src/options.c
+++ b/src/options.c
@@ -277,7 +277,7 @@ cmd_help (void)
   "                                    visitors count.\n"
   "  --all-static-files              - Include static files with a query string.\n"
   "  --anonymize-ip                  - Anonymize IP addresses before outputting to\n"
-  "                                    report. Note that this deactivates --agent-list.\n"
+  "                                    report.\n"
   "  --anonymize-level=<1|2|3>       - Anonymization levels: 1 => default, 2 =>\n"
   "                                    strong, 3 => pedantic.\n"
   "  --chunk-size=<256-32768>        - Number of lines processed in each data chunk\n"

--- a/src/options.c
+++ b/src/options.c
@@ -277,7 +277,7 @@ cmd_help (void)
   "                                    visitors count.\n"
   "  --all-static-files              - Include static files with a query string.\n"
   "  --anonymize-ip                  - Anonymize IP addresses before outputting to\n"
-  "                                    report.\n"
+  "                                    report. Note that this deactivates --agent-list.\n"
   "  --anonymize-level=<1|2|3>       - Anonymization levels: 1 => default, 2 =>\n"
   "                                    strong, 3 => pedantic.\n"
   "  --chunk-size=<256-32768>        - Number of lines processed in each data chunk\n"


### PR DESCRIPTION
just some small changes to the documentation:

- mount the report file in the docker documentation (so juniors will have a few less google searches on how to access the result)
- add a note about the contradiction between `-a` and `--anonymize-ip`

again please not that I have no knowledge of the documentation engine you are using so feel free to hint me to other locations where this needs adaption.