### PR TITLE
fix: add android 12.1 in operating systems

### DIFF
--- a/src/opesys.c
+++ b/src/opesys.c
@@ -132,6 +132,8 @@ get_real_android (const char *droid) {
     return alloc_string ("Android 13");
   else if (strstr (droid, "12"))
     return alloc_string ("Android 12");
+  else if (strstr (droid, "12.1"))
+    return alloc_string ("Android 12.1");
   else if (strstr (droid, "11"))
     return alloc_string ("Android 11");
   else if (strstr (droid, "10"))


### PR DESCRIPTION
When processing requests from Android version 12.1, the report was generated as Eclair 2