### PR TITLE
Extract referer host more reliably

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -477,7 +477,7 @@ extract_referer_site (const char *referer, char *host) {
   if ((len = strlen (begin)) == 0)
     goto clean;
 
-  if ((end = strchr (begin, '/')) != NULL)
+  if ((end = strpbrk (begin, "/?")) != NULL)
     len = end - begin;
 
   if (len == 0)


### PR DESCRIPTION
This fixes a bug, where the referer parser chokes on some rare URLs where the URLs parameter appear without a `'/'` character marking the end of the host, e.g. the following URL:

```
https://example.com?ref=https%3A//giter.vip
```

Before this fix, goaccess would mistakenly display `"https://example.com?ref=https%3A"` as the referer host.

Example nginx log file:

```
1.2.3.4 - - [07/Jul/2023:19:12:21 +0200] "GET /example/ HTTP/1.1" 200 5910 "https://example.com?ref=https%3A//giter.vip" "Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com/site/petalbot)"
```

While it is more common to have a `'/'` before the URL parameters, the above is perfectly valid according to the spec, see here: https://url.spec.whatwg.org/#url-writing

Thus, this patch fixes this by also considering `'?'` as an end marker.
