### PR TITLE
Use `client_ip` for Caddy JSON, allowing trusted proxies

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -113,7 +113,7 @@
 #log-format %^ %^ [%h] %^ %^ [%d:%t %^] "%r" %s %b "%R" "%u" %^ %^ [%v] %^:%^ %^ %T %^ %^
 
 # CADDY JSON Structured
-#log-format {"ts":"%x.%^","request":{"remote_ip":"%h","proto":"%H","method":"%m","host":"%v","uri":"%U","headers":{"User-Agent":["%u"],"Referer":["%R"]},"tls":{"cipher_suite":"%k","proto": "%K"}},"duration": "%T","size": "%b","status": "%s","resp_headers":{"Content-Type":["%M"]}}
+#log-format {"ts":"%x.%^","request":{"client_ip":"%h","proto":"%H","method":"%m","host":"%v","uri":"%U","headers":{"User-Agent":["%u"],"Referer":["%R"]},"tls":{"cipher_suite":"%k","proto": "%K"}},"duration": "%T","size": "%b","status": "%s","resp_headers":{"Content-Type":["%M"]}}
 
 # Treaefik CLF flavor
 #log-format %h - %e [%d:%t %^] "%r" %s %b "%R" "%u" %^ "%v" "%U" %Lms

--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -113,7 +113,7 @@
 #log-format %^ %^ [%h] %^ %^ [%d:%t %^] "%r" %s %b "%R" "%u" %^ %^ [%v] %^:%^ %^ %T %^ %^
 
 # CADDY JSON Structured
-#log-format {"ts":"%x.%^","request":{"remote_ip":"%h","proto":"%H","method":"%m","host":"%v","uri":"%U","headers":{"User-Agent":["%u","%^"]},"tls":{"cipher_suite":"%k","proto": "%K"}},"duration": "%T","size": "%b","status": "%s","resp_headers":{"Content-Type":["%M;%^"]}}
+#log-format {"ts":"%x.%^","request":{"remote_ip":"%h","proto":"%H","method":"%m","host":"%v","uri":"%U","headers":{"User-Agent":["%u"],"Referer":["%R"]},"tls":{"cipher_suite":"%k","proto": "%K"}},"duration": "%T","size": "%b","status": "%s","resp_headers":{"Content-Type":["%M"]}}
 
 # Treaefik CLF flavor
 #log-format %h - %e [%d:%t %^] "%r" %s %b "%R" "%u" %^ "%v" "%U" %Lms

--- a/src/settings.c
+++ b/src/settings.c
@@ -79,7 +79,7 @@ static const GPreConfLog logs = {
   "%^ %v [%d:%t %^] %h %^\"%r\" %s %^ %b %^ %L %^ \"%R\" \"%u\"", /* Amazon S3 */
 
   /* Caddy JSON */
-  "{ \"ts\": \"%x.%^\", \"request\": { \"remote_ip\": \"%h\", \"proto\":"
+  "{ \"ts\": \"%x.%^\", \"request\": { \"client_ip\": \"%h\", \"proto\":"
   "\"%H\", \"method\": \"%m\", \"host\": \"%v\", \"uri\": \"%U\", \"headers\": {"
   "\"User-Agent\": [\"%u\"], \"Referer\": [\"%R\"] }, \"tls\": { \"cipher_suite\":"
   "\"%k\", \"proto\": \"%K\" } }, \"duration\": \"%T\", \"size\": \"%b\","


### PR DESCRIPTION
Caddy has added [first-class support for determining client IP](https://github.com/caddyserver/caddy/pull/5104), which means that from Caddy 2.7 beta 1 onwards, the logs include `client_ip` alongside `remote_ip` in the access logs. The value falls back to `remote_ip`'s value, meaning this has no impact on Caddy configurations that don't use trusted proxies.

> the client_ip should always be set (as long as the RemoteAddr is a valid IP address). So in the logs, it will be identical to the remote_ip unless trusted proxies is configured and the proxy passed the client IP in a trusted header.

If trusted proxies are [configured globally](https://caddyserver.com/docs/caddyfile/options#trusted-proxies), Caddy will follow your configuration for determining which proxies are trusted and what headers to use. For example, this allows you to forward traffic from one of your servers to another while trusting IP addresses in the private range.