### PR TITLE
update ncurses dependency for Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ build GoAccess from source.
 
 | Distro                 | NCurses          | GeoIP (opt)      | GeoIP2 (opt)          |  OpenSSL (opt)     |
 | ---------------------- | ---------------- | ---------------- | --------------------- | -------------------|
-| **Ubuntu/Debian**      | libncursesw6-dev | libgeoip-dev     | libmaxminddb-dev      |  libssl-dev        |
+| **Ubuntu/Debian**      | libncurses-dev   | libgeoip-dev     | libmaxminddb-dev      |  libssl-dev        |
 | **RHEL/CentOS**        | ncurses-devel    | geoip-devel      | libmaxminddb-devel    |  openssl-devel     |
 | **Arch**               | ncurses          | geoip            | libmaxminddb          |  openssl           |
 | **Gentoo**             | sys-libs/ncurses | dev-libs/geoip   | dev-libs/libmaxminddb |  dev-libs/openssl  |


### PR DESCRIPTION
As of (at least) Ubuntu 22.04 LTS and Debian Buster, there is no longer a `w6-dev` package. The build works as expected with `libncurses-dev` instead.

This is a quick fix only based on the latest releases to keep the readme simple. Please reject this patch if you intend to maintain docs for older Ubuntu/Debian versions.

I tested in a `ubuntu:22.04` container. I installed these packages prior to building:

* autoconf
* automake
* autopoint
* gcc
* gettext
* libncurses-dev
* libgeoip-dev
* libmaxminddb-dev
* libssl-dev
* build-essential