### PR TITLE
Miscellaneous bug fixes and improvements

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -47,7 +47,7 @@
 static char ***browsers_hash = NULL;
 
 /* {"search string", "belongs to"} */
-static const char *browsers[][2] = {
+static const char *const browsers[][2] = {
   /* Game systems: most of them are based on major browsers,
    * thus they need to go before. */
   {"Xbox One", "Game Systems"},

--- a/src/color.c
+++ b/src/color.c
@@ -49,7 +49,7 @@ static GSLList *color_list = NULL;
 static GSLList *pair_list = NULL;
 
 /* *INDENT-OFF* */
-static GEnum CSTM_COLORS[] = {
+static const GEnum CSTM_COLORS[] = {
   {"COLOR_MTRC_HITS"              , COLOR_MTRC_HITS},
   {"COLOR_MTRC_VISITORS"          , COLOR_MTRC_VISITORS},
   {"COLOR_MTRC_HITS_PERC"         , COLOR_MTRC_HITS_PERC},
@@ -79,7 +79,7 @@ static GEnum CSTM_COLORS[] = {
   {"COLOR_PROGRESS"               , COLOR_PROGRESS},
 };
 
-static const char *colors256_mono[] = {
+static const char *const colors256_mono[] = {
   "COLOR_MTRC_HITS              color7:color-1",
   "COLOR_MTRC_VISITORS          color8:color-1",
   "COLOR_MTRC_DATA              color7:color-1",
@@ -117,7 +117,7 @@ static const char *colors256_mono[] = {
   "COLOR_PROGRESS               color0:color6",
 };
 
-static const char *colors256_green[] = {
+static const char *const colors256_green[] = {
   "COLOR_MTRC_HITS              color7:color-1",
   "COLOR_MTRC_VISITORS          color8:color-1",
   "COLOR_MTRC_DATA              color7:color-1",
@@ -155,7 +155,7 @@ static const char *colors256_green[] = {
   "COLOR_PROGRESS               color0:color6",
 };
 
-static const char *colors256_monokai[] = {
+static const char *const colors256_monokai[] = {
   "COLOR_MTRC_HITS              color197:color-1",
   "COLOR_MTRC_VISITORS          color148:color-1",
   "COLOR_MTRC_DATA              color7:color-1",
@@ -193,7 +193,7 @@ static const char *colors256_monokai[] = {
   "COLOR_PROGRESS               color7:color141",
 };
 
-static const char *colors8_mono[] = {
+static const char *const colors8_mono[] = {
   "COLOR_MTRC_HITS              color7:color-1",
   "COLOR_MTRC_VISITORS          color0:color-1 bold",
   "COLOR_MTRC_DATA              color7:color-1",
@@ -231,7 +231,7 @@ static const char *colors8_mono[] = {
   "COLOR_PROGRESS               color0:color6",
 };
 
-static const char *colors8_green[] = {
+static const char *const colors8_green[] = {
   "COLOR_MTRC_HITS              color7:color-1",
   "COLOR_MTRC_VISITORS          color0:color-1 bold",
   "COLOR_MTRC_DATA              color7:color-1",
@@ -269,7 +269,7 @@ static const char *colors8_green[] = {
   "COLOR_PROGRESS               color0:color6",
 };
 
-static const char *nocolors[] = {
+static const char *const nocolors[] = {
   "COLOR_MTRC_HITS              color0:color-1",
   "COLOR_MTRC_VISITORS          color0:color-1",
   "COLOR_MTRC_DATA              color0:color-1",
@@ -753,7 +753,7 @@ parse_color (char *line) {
  * On error, it aborts.
  * On success, the color properties are parsed and stored */
 static void
-parse_colors (const char *colors[], size_t n) {
+parse_colors (const char *const colors[], size_t n) {
   char *line;
   size_t i;
 

--- a/src/commons.c
+++ b/src/commons.c
@@ -196,13 +196,13 @@ str2enum (const GEnum map[], int len, const char *str) {
  *
  * On error, -1 is returned.
  * On success, the enumerated module value is returned. */
-char *
+const char *
 enum2str (const GEnum map[], int len, int idx) {
   int i;
 
   for (i = 0; i < len; ++i) {
     if (idx == map[i].idx)
-      return xstrdup (map[i].str);
+      return map[i].str;
   }
 
   return NULL;
@@ -221,7 +221,7 @@ get_module_enum (const char *str) {
  *
  * On error, NULL is returned.
  * On success, the string module value is returned. */
-char *
+const char *
 get_module_str (GModule module) {
   return enum2str (enum_modules, ARRAY_SIZE (enum_modules), module);
 }

--- a/src/commons.c
+++ b/src/commons.c
@@ -54,7 +54,7 @@ int module_list[TOTAL_MODULES] = {[0 ... TOTAL_MODULES - 1] = -1 };
 
 /* *INDENT-OFF* */
 /* String modules to enumerated modules */
-static GEnum enum_modules[] = {
+static const GEnum enum_modules[] = {
   {"VISITORS"        , VISITORS}        ,
   {"REQUESTS"        , REQUESTS}        ,
   {"REQUESTS_STATIC" , REQUESTS_STATIC} ,

--- a/src/commons.h
+++ b/src/commons.h
@@ -262,8 +262,8 @@ extern int module_list[TOTAL_MODULES];
 GAgents *new_gagents (uint32_t size);
 void free_agents_array (GAgents *agents);
 
-char *enum2str (const GEnum map[], int len, int idx);
-char *get_module_str (GModule module);
+const char *enum2str (const GEnum map[], int len, int idx);
+const char *get_module_str (GModule module);
 float get_percentage (unsigned long long total, unsigned long long hit);
 int get_max_choices (void);
 int get_module_enum (const char *str);

--- a/src/csv.c
+++ b/src/csv.c
@@ -60,7 +60,7 @@ static void print_csv_data (FILE * fp, GHolder * h, GPercTotals totals);
 
 /* *INDENT-OFF* */
 /* A function pointer for each panel */
-static GPanel paneling[] = {
+static const GPanel paneling[] = {
   {VISITORS        , print_csv_data} ,
   {REQUESTS        , print_csv_data} ,
   {REQUESTS_STATIC , print_csv_data} ,
@@ -89,7 +89,7 @@ static GPanel paneling[] = {
  *
  * On error, or if not found, NULL is returned.
  * On success, the panel value is returned. */
-static GPanel *
+static const GPanel *
 panel_lookup (GModule module) {
   int i, num_panels = ARRAY_SIZE (paneling);
 

--- a/src/gholder.c
+++ b/src/gholder.c
@@ -60,7 +60,7 @@ static void add_host_to_holder (GRawDataItem item, GHolder * h, datatype type, c
 static void add_root_to_holder (GRawDataItem item, GHolder * h, datatype type, const GPanel * panel);
 static void add_host_child_to_holder (GHolder * h);
 
-static GPanel paneling[] = {
+static const GPanel paneling[] = {
   {VISITORS        , add_data_to_holder , NULL},
   {REQUESTS        , add_data_to_holder , NULL},
   {REQUESTS_STATIC , add_data_to_holder , NULL},
@@ -90,7 +90,7 @@ static GPanel paneling[] = {
  *
  * On error, or if not found, NULL is returned.
  * On success, the panel value is returned. */
-static GPanel *
+static const GPanel *
 panel_lookup (GModule module) {
   int i, num_panels = ARRAY_SIZE (paneling);
 
@@ -526,8 +526,8 @@ add_host_to_holder (GRawDataItem item, GHolder *h, datatype type, const GPanel *
     "ffff:ffff:0000:0000:0000:0000:0000:0000"
   };
 
-  char *m4 = (char *) arr4[0];
-  char *m6 = (char *) arr6[0];
+  const char *m4 = arr4[0];
+  const char *m6 = arr6[0];
 
   if (map_data (h->module, item, type, &data, &hits) == 1)
     return;
@@ -539,8 +539,8 @@ add_host_to_holder (GRawDataItem item, GHolder *h, datatype type, const GPanel *
   }
 
   if (conf.anonymize_level == ANONYMIZE_STRONG || conf.anonymize_level == ANONYMIZE_PEDANTIC) {
-    m4 = (char *) arr4[conf.anonymize_level - 1];
-    m6 = (char *) arr6[conf.anonymize_level - 1];
+    m4 = arr4[conf.anonymize_level - 1];
+    m6 = arr6[conf.anonymize_level - 1];
   }
 
   if (1 == inet_pton (AF_INET, data, &addr4)) {

--- a/src/gholder.c
+++ b/src/gholder.c
@@ -656,7 +656,7 @@ load_holder_data (GRawData *raw_data, GHolder *h, GModule module, GSort sort) {
 #ifdef _DEBUG
   clock_t begin = clock ();
   double taken;
-  char *modstr = NULL;
+  const char *modstr = NULL;
   LOG_DEBUG (("== load_holder_data ==\n"));
 #endif
 
@@ -680,6 +680,5 @@ load_holder_data (GRawData *raw_data, GHolder *h, GModule module, GSort sort) {
   modstr = get_module_str (module);
   taken = (double) (clock () - begin) / CLOCKS_PER_SEC;
   LOG_DEBUG (("== %-30s%f\n\n", modstr, taken));
-  free (modstr);
 #endif
 }

--- a/src/gkhash.c
+++ b/src/gkhash.c
@@ -71,7 +71,7 @@ new_gkdb (void) {
  *
  * On error, NULL is returned.
  * On success, the string module value is returned. */
-char *
+const char *
 get_mtr_type_str (GSMetricType type) {
   static const GEnum enum_metric_types[] = {
     {"II32", MTRC_TYPE_II32},

--- a/src/gkhash.c
+++ b/src/gkhash.c
@@ -73,7 +73,7 @@ new_gkdb (void) {
  * On success, the string module value is returned. */
 char *
 get_mtr_type_str (GSMetricType type) {
-  GEnum enum_metric_types[] = {
+  static const GEnum enum_metric_types[] = {
     {"II32", MTRC_TYPE_II32},
     {"IS32", MTRC_TYPE_IS32},
     {"IU64", MTRC_TYPE_IU64},
@@ -541,7 +541,7 @@ const GKHashMetric app_metrics[] = {
   { .metric.dbm=MTRC_DB_PROPS    , MTRC_TYPE_SI32 , new_si32_ht , des_si32_free , del_si32_free , 1 , NULL , "SI32_DB_PROPS.db"    } ,
 };
 
-size_t app_metrics_len = ARRAY_SIZE (app_metrics);
+const size_t app_metrics_len = ARRAY_SIZE (app_metrics);
 /* *INDENT-ON* */
 
 /* Destroys malloc'd module metrics */

--- a/src/gkhash.h
+++ b/src/gkhash.h
@@ -185,7 +185,7 @@ uint32_t *get_sorted_dates (uint32_t * len);
 void free_storage (void);
 void init_pre_storage (Logs *logs);
 
-char *get_mtr_type_str (GSMetricType type);
+const char *get_mtr_type_str (GSMetricType type);
 void *get_db_instance (uint32_t key);
 void *get_hdb (GKDB * db, GAMetric mtrc);
 

--- a/src/gkhash.h
+++ b/src/gkhash.h
@@ -110,7 +110,7 @@ struct GKDB_ {
   } }
 
 extern const GKHashMetric app_metrics[];
-extern size_t app_metrics_len;
+extern const size_t app_metrics_len;
 
 /* *INDENT-OFF* */
 void *new_igsl_ht (void);

--- a/src/gkmhash.c
+++ b/src/gkmhash.c
@@ -52,7 +52,7 @@ const GKHashMetric global_metrics[] = {
 };
 
 /* Per module & per date */
-GKHashMetric module_metrics[] = {
+const GKHashMetric module_metrics[] = {
   { .metric.storem=MTRC_KEYMAP    , MTRC_TYPE_II32 , new_ii32_ht , des_ii32      , del_ii32      , 1 , NULL , NULL } ,
   { .metric.storem=MTRC_ROOTMAP   , MTRC_TYPE_IS32 , new_is32_ht , des_is32_free , del_is32_free , 1 , NULL , NULL } ,
   { .metric.storem=MTRC_DATAMAP   , MTRC_TYPE_IS32 , new_is32_ht , des_is32_free , del_is32_free , 1 , NULL , NULL } ,
@@ -68,8 +68,8 @@ GKHashMetric module_metrics[] = {
   { .metric.storem=MTRC_AGENTS    , MTRC_TYPE_IGSL , new_igsl_ht , des_igsl_free , del_igsl_free , 1 , NULL , NULL } ,
   { .metric.storem=MTRC_METADATA  , MTRC_TYPE_SU64 , new_su64_ht , des_su64_free , del_su64_free , 1 , NULL , NULL } ,
 };
-size_t module_metrics_len = ARRAY_SIZE (module_metrics);
-size_t global_metrics_len = ARRAY_SIZE (global_metrics);
+const size_t module_metrics_len = ARRAY_SIZE (module_metrics);
+const size_t global_metrics_len = ARRAY_SIZE (global_metrics);
 /* *INDENT-ON* */
 
 /* Allocate memory for a new store container GKHashStorage instance.

--- a/src/gkmhash.c
+++ b/src/gkmhash.c
@@ -1439,7 +1439,7 @@ parse_raw_data (GModule module) {
 #ifdef _DEBUG
   clock_t begin = clock ();
   double taken;
-  char *modstr = NULL;
+  const char *modstr = NULL;
   LOG_DEBUG (("== parse_raw_data ==\n"));
 #endif
 
@@ -1459,7 +1459,6 @@ parse_raw_data (GModule module) {
   modstr = get_module_str (module);
   taken = (double) (clock () - begin) / CLOCKS_PER_SEC;
   LOG_DEBUG (("== %-30s%f\n\n", modstr, taken));
-  free (modstr);
 #endif
 
   return raw_data;

--- a/src/gkmhash.c
+++ b/src/gkmhash.c
@@ -420,7 +420,7 @@ ht_insert_keymap (GModule module, uint32_t date, uint32_t key, uint32_t *ckey) {
   khash_t (ii32) * cache = get_hash_from_cache (module, MTRC_KEYMAP);
 
   uint32_t val = 0;
-  char *modstr = NULL;
+  const char *modstr;
 
   if (!hash)
     return 0;
@@ -432,11 +432,9 @@ ht_insert_keymap (GModule module, uint32_t date, uint32_t key, uint32_t *ckey) {
 
   modstr = get_module_str (module);
   if ((val = ins_ii32_inc (hash, key, ht_ins_seq, seqs, modstr)) == 0) {
-    free (modstr);
     return val;
   }
   *ckey = ins_ii32_ai (cache, key);
-  free (modstr);
 
   return val;
 }

--- a/src/gkmhash.h
+++ b/src/gkmhash.h
@@ -211,10 +211,10 @@ struct GKHashStorage_ {
 /*khash_t(igsl) MTRC_METADATA */
 
 /* *INDENT-OFF* */
-extern GKHashMetric module_metrics[];
+extern const GKHashMetric module_metrics[];
 extern const GKHashMetric global_metrics[];
-extern size_t global_metrics_len;
-extern size_t module_metrics_len;
+extern const size_t global_metrics_len;
+extern const size_t module_metrics_len;
 
 char *ht_get_datamap (GModule module, uint32_t key);
 char *ht_get_host_agent_val (uint32_t key);

--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -121,7 +121,7 @@ const httpmethods http_methods[] = {
   { "MKACTIVITY"       , 10 } ,
   { "ORDERPATCH"       , 10 } ,
 };
-size_t http_methods_len = ARRAY_SIZE (http_methods);
+const size_t http_methods_len = ARRAY_SIZE (http_methods);
 
 const httpprotocols http_protocols[] = {
   { "HTTP/1.0" , 8 } ,
@@ -129,9 +129,9 @@ const httpprotocols http_protocols[] = {
   { "HTTP/2"   , 6 } ,
   { "HTTP/3"   , 6 } ,
 };
-size_t http_protocols_len = ARRAY_SIZE (http_protocols);
+const size_t http_protocols_len = ARRAY_SIZE (http_protocols);
 
-static GParse paneling[] = {
+static const GParse paneling[] = {
   {
     VISITORS,
     gen_visitor_key,
@@ -408,7 +408,7 @@ new_modulekey (GKeyData *kdata) {
  *
  * On error, or if not found, NULL is returned.
  * On success, the panel value is returned. */
-static GParse *
+static const GParse *
 panel_lookup (GModule module) {
   int i, num_panels = ARRAY_SIZE (paneling);
 
@@ -448,7 +448,7 @@ free_gmetrics (GMetrics *metric) {
 char *
 get_mtr_str (GSMetric metric) {
   /* String modules to enumerated modules */
-  GEnum enum_metrics[] = {
+  static const GEnum enum_metrics[] = {
     {"MTRC_KEYMAP", MTRC_KEYMAP},
     {"MTRC_ROOTMAP", MTRC_ROOTMAP},
     {"MTRC_DATAMAP", MTRC_DATAMAP},

--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -445,7 +445,7 @@ free_gmetrics (GMetrics *metric) {
  *
  * On error, NULL is returned.
  * On success, the string module value is returned. */
-char *
+const char *
 get_mtr_str (GSMetric metric) {
   /* String modules to enumerated modules */
   static const GEnum enum_metrics[] = {

--- a/src/gstorage.h
+++ b/src/gstorage.h
@@ -140,8 +140,8 @@ typedef struct httpprotocols_ {
 
 extern const httpmethods http_methods[];
 extern const httpprotocols http_protocols[];
-extern size_t http_methods_len;
-extern size_t http_protocols_len;
+extern const size_t http_methods_len;
+extern const size_t http_protocols_len;
 
 char *get_mtr_str (GSMetric metric);
 int excluded_ip (GLogItem * logitem);

--- a/src/gstorage.h
+++ b/src/gstorage.h
@@ -143,7 +143,7 @@ extern const httpprotocols http_protocols[];
 extern const size_t http_methods_len;
 extern const size_t http_protocols_len;
 
-char *get_mtr_str (GSMetric metric);
+const char *get_mtr_str (GSMetric metric);
 int excluded_ip (GLogItem * logitem);
 uint32_t *i322ptr (uint32_t val);
 uint64_t *uint642ptr (uint64_t val);

--- a/src/json.c
+++ b/src/json.c
@@ -69,7 +69,7 @@ static void print_json_sub_items (GJSON * json, GHolderItem * item,
                                   GPercTotals totals, int size, int iisp);
 
 /* *INDENT-OFF* */
-static GPanel paneling[] = {
+static const GPanel paneling[] = {
   {VISITORS            , print_json_data , NULL } ,
   {REQUESTS            , print_json_data , NULL } ,
   {REQUESTS_STATIC     , print_json_data , NULL } ,
@@ -99,7 +99,7 @@ static GPanel paneling[] = {
  *
  * If not found, NULL is returned.
  * On success, panel data is returned . */
-static GPanel *
+static const GPanel *
 panel_lookup (GModule module) {
   int i, num_panels = ARRAY_SIZE (paneling);
 

--- a/src/opesys.c
+++ b/src/opesys.c
@@ -42,7 +42,7 @@
  * which makes this pretty slow */
 
 /* {"search string", "belongs to"} */
-static const char *os[][2] = {
+static const char *const os[][2] = {
   {"Android", "Android"},
   {"Windows NT 10.0", "Windows"},
   {"Windows NT 6.3; ARM", "Windows"},

--- a/src/options.c
+++ b/src/options.c
@@ -50,14 +50,14 @@
 
 #include "xmalloc.h"
 
-static char short_options[] = "b:e:f:j:l:o:p:H:M:S:"
+static const char *short_options = "b:e:f:j:l:o:p:H:M:S:"
 #ifdef HAVE_LIBGEOIP
   "g"
 #endif
   "acdhimqrsV";
 
 /* *INDENT-OFF* */
-struct option long_opts[] = {
+static const struct option long_opts[] = {
   {"agent-list"           , no_argument       , 0 , 'a' } ,
   {"browsers-file"        , required_argument , 0 , 'b' } ,
   {"config-dialog"        , no_argument       , 0 , 'c' } ,

--- a/src/output.c
+++ b/src/output.c
@@ -68,7 +68,7 @@ static void print_metrics (FILE * fp, const GHTML * def, int sp);
 static void print_host_metrics (FILE * fp, const GHTML * def, int sp);
 
 /* *INDENT-OFF* */
-static GHTML htmldef[] = {
+static const GHTML htmldef[] = {
   {VISITORS, 1, 0, print_metrics, {
     {CHART_AREASPLINE, hits_visitors_plot, 1, 1, NULL, NULL} ,
     {CHART_AREASPLINE, hits_bw_plot, 1, 1, NULL, NULL} ,
@@ -168,7 +168,7 @@ chart2str (GChartType type) {
  *
  * If not found, NULL is returned.
  * On success, panel data is returned . */
-static GHTML *
+static const GHTML *
 panel_lookup (GModule module) {
   int i, num_panels = ARRAY_SIZE (htmldef);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -360,14 +360,14 @@ free_glog (GLogItem *logitem) {
 /* Decodes the given URL-encoded string.
  *
  * On success, the decoded string is assigned to the output buffer. */
-#define B16210(x) (((x) >= '0' && (x) <= '9') ? ((x) - '0') : (toupper((x)) - 'A' + 10))
+#define B16210(x) (((x) >= '0' && (x) <= '9') ? ((x) - '0') : (toupper((unsigned char) (x)) - 'A' + 10))
 static void
 decode_hex (char *url, char *out) {
   char *ptr;
   const char *c;
 
   for (c = url, ptr = out; *c; c++) {
-    if (*c != '%' || !isxdigit (c[1]) || !isxdigit (c[2])) {
+    if (*c != '%' || !isxdigit ((unsigned char) c[1]) || !isxdigit ((unsigned char) c[2])) {
       *ptr++ = *c;
     } else {
       *ptr++ = (char) ((B16210 (c[1]) * 16) + (B16210 (c[2])));
@@ -760,7 +760,7 @@ static void
 find_alpha (const char **str) {
   const char *s = *str;
   while (*s) {
-    if (isspace (*s))
+    if (isspace ((unsigned char) *s))
       s++;
     else
       break;
@@ -775,7 +775,7 @@ find_alpha_count (const char *str) {
   int cnt = 0;
   const char *s = str;
   while (*s) {
-    if (isspace (*s))
+    if (isspace ((unsigned char) *s))
       s++, cnt++;
     else
       break;
@@ -1274,7 +1274,7 @@ parse_specifier (GLogItem *logitem, const char **str, const char *p, const char 
 #if defined(HAVE_LIBSSL) && defined(HAVE_CIPHER_STD_NAME)
     {
       char *tmp = NULL;
-      for (tmp = tkn; isdigit (*tmp); tmp++);
+      for (tmp = tkn; isdigit ((unsigned char) *tmp); tmp++);
       if (!strlen (tmp))
         extract_tls_version_cipher (tkn, &logitem->tls_cypher, &logitem->tls_type);
       else
@@ -1512,7 +1512,7 @@ parse_format (GLogItem *logitem, const char *str, const char *lfmt) {
       if ((ret = parse_specifier (logitem, &str, p, end)))
         return ret;
       perc = 0;
-    } else if (perc && isspace (p[0])) {
+    } else if (perc && isspace ((unsigned char) p[0])) {
       return 1;
     } else {
       str++;

--- a/src/persistence.c
+++ b/src/persistence.c
@@ -332,7 +332,7 @@ migrate_si32_to_ii32 (GSMetric metric, const char *path, int module) {
       break;
 
     while (tpl_unpack (tn, 2) > 0) {
-      ins_ii32 (hash, djb2 ((unsigned char *) key), val);
+      ins_ii32 (hash, djb2 ((const unsigned char *) key), val);
       free (key);
     }
   }
@@ -364,7 +364,7 @@ migrate_unique_key (const char *key) {
     delims++;
   }
   if (delims == 2) {
-    sprintf (agent_hex, "%" PRIx32, djb2 ((unsigned char *) key));
+    sprintf (agent_hex, "%" PRIx32, djb2 ((const unsigned char *) key));
     append_str (&nkey, agent_hex);
   }
 

--- a/src/persistence.c
+++ b/src/persistence.c
@@ -232,7 +232,8 @@ build_filename (const char *type, const char *modstr, const char *mtrstr) {
  * On success, the filename is returned */
 static char *
 get_filename (GModule module, GKHashMetric mtrc) {
-  char *mtrstr = NULL, *modstr = NULL, *type = NULL, *fn = NULL;
+  const char *mtrstr, *modstr, *type;
+  char *fn = NULL;
 
   if (!(mtrstr = get_mtr_str (mtrc.metric.storem)))
     FATAL ("Unable to allocate metric name.");
@@ -242,10 +243,6 @@ get_filename (GModule module, GKHashMetric mtrc) {
     FATAL ("Unable to allocate module name.");
 
   fn = build_filename (type, modstr, mtrstr);
-
-  free (mtrstr);
-  free (type);
-  free (modstr);
 
   return fn;
 }
@@ -945,7 +942,7 @@ migrate_metric (GModule module, GKHashMetric mtrc) {
 
   int ret = 0;
   char *fn = NULL, *path = NULL;
-  char *modstr = NULL, *mtrstr = NULL;
+  const char *modstr, *mtrstr;
   khint_t k;
 
   k = kh_get (si32, db_props, "version");
@@ -1001,8 +998,6 @@ migrate_metric (GModule module, GKHashMetric mtrc) {
   }
 
   free (fn);
-  free (modstr);
-  free (mtrstr);
   free (path);
 
   return ret;

--- a/src/settings.c
+++ b/src/settings.c
@@ -50,7 +50,7 @@ static char **nargv;
 static int nargc = 0;
 
 /* *INDENT-OFF* */
-static GEnum LOGTYPE[] = {
+static const GEnum LOGTYPE[] = {
   {"COMBINED"     , COMBINED}     ,
   {"VCOMBINED"    , VCOMBINED}    ,
   {"COMMON"       , COMMON}       ,
@@ -105,7 +105,7 @@ static const GPreConfDate dates = {
 /* *INDENT-ON* */
 
 /* Ignore the following options */
-static const char *ignore_cmd_opts[] = {
+static const char *const ignore_cmd_opts[] = {
   "help",
   "storage",
   "version",
@@ -172,7 +172,7 @@ get_config_file_path (void) {
 void
 set_default_static_files (void) {
   size_t i;
-  const char *exts[] = {
+  const char *const exts[] = {
     ".css",
     ".js ",
     ".jpg",

--- a/src/sort.c
+++ b/src/sort.c
@@ -85,7 +85,7 @@ const int sort_choices[][SORT_MAX_OPTS] = {
   {SORT_BY_HITS, SORT_BY_DATA, SORT_BY_VISITORS, SORT_BY_BW, -1},
 };
 
-static GEnum FIELD[] = {
+static const GEnum FIELD[] = {
   {"BY_HITS"     , SORT_BY_HITS     } ,
   {"BY_VISITORS" , SORT_BY_VISITORS } ,
   {"BY_DATA"     , SORT_BY_DATA     } ,
@@ -97,7 +97,7 @@ static GEnum FIELD[] = {
   {"BY_MTHD"     , SORT_BY_MTHD     } ,
 };
 
-static GEnum ORDER[] = {
+static const GEnum ORDER[] = {
   {"ASC"  , SORT_ASC  } ,
   {"DESC" , SORT_DESC } ,
 };
@@ -403,7 +403,7 @@ get_sort_field_str (GSortField field) {
  * The key corresponding to the enumerated field value is returned. */
 const char *
 get_sort_field_key (GSortField field) {
-  static const char *field2key[][2] = {
+  static const char *const field2key[][2] = {
     {"BY_HITS", "hits"},
     {"BY_VISITORS", "visitors"},
     {"BY_DATA", "data"},

--- a/src/ui.c
+++ b/src/ui.c
@@ -68,7 +68,7 @@
 
 /* *INDENT-OFF* */
 /* Determine which metrics should be displayed per module/panel */
-static GOutput outputting[] = {
+static const GOutput outputting[] = {
   {VISITORS        , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 0 , 0 , 1 , 1 , 1} ,
   {REQUESTS        , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 0 , 0} ,
   {REQUESTS_STATIC , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 1 , 0 , 0} ,
@@ -107,7 +107,7 @@ typedef struct Field_ {
  *
  * On error, or if not found, NULL is returned.
  * On success, the panel value is returned. */
-GOutput *
+const GOutput *
 output_lookup (GModule module) {
   int i, num_panels = ARRAY_SIZE (outputting);
 
@@ -259,7 +259,7 @@ term_size (WINDOW *main_win, int *main_win_height) {
  * On success, a string containing the label name is returned. */
 const char *
 module_to_label (GModule module) {
-  static const char *modules[] = {
+  static const char *const modules[] = {
     VISITORS_LABEL,
     REQUESTS_LABEL,
     REQUESTS_STATIC_LABEL,
@@ -291,7 +291,7 @@ module_to_label (GModule module) {
  * On success, a string containing the label id is returned. */
 const char *
 module_to_id (GModule module) {
-  static const char *modules[] = {
+  static const char *const modules[] = {
     VISITORS_ID,
     REQUESTS_ID,
     REQUESTS_STATIC_ID,
@@ -359,7 +359,7 @@ module_to_head (GModule module) {
  * On success, a string containing the label description is returned. */
 const char *
 module_to_desc (GModule module) {
-  static const char *modules[] = {
+  static const char *const modules[] = {
     VISITORS_DESC,
     REQUESTS_DESC,
     REQUESTS_STATIC_DESC,
@@ -1298,7 +1298,7 @@ render_confdlg (Logs *logs, GSpinner *spinner) {
   size_t i, n, sel;
 
   /* conf dialog menu options */
-  const char *choices[] = {
+  static const char *const choices[] = {
     "NCSA Combined Log Format",
     "NCSA Combined Log Format with Virtual Host",
     "Common Log Format (CLF)",
@@ -1817,7 +1817,7 @@ load_sort_win (WINDOW *main_win, GModule module, GSort *sort) {
 }
 
 /* Help menu data (F1/h). */
-static const char *help_main[] = {
+static const char *const help_main[] = {
   "Copyright (C) 2009-2024 by Gerardo Orellana",
   "https://goaccess.io - <hello@goaccess.io>",
   "Released under the MIT License.",

--- a/src/ui.c
+++ b/src/ui.c
@@ -805,7 +805,7 @@ input_string (WINDOW *win, int pos_y, int pos_x, size_t max_width, const char *s
     default:
       if (strlen (s) == max_width)
         break;
-      if (!isprint (c))
+      if (!isprint ((unsigned char) c))
         break;
 
       if (strlen (s) == pos) {

--- a/src/ui.h
+++ b/src/ui.h
@@ -222,7 +222,7 @@ typedef struct GOutput_ {
 } GOutput;
 
 /* *INDENT-OFF* */
-GOutput *output_lookup (GModule module);
+const GOutput *output_lookup (GModule module);
 GSpinner *new_gspinner (void);
 
 char *get_browser_type (char *line);

--- a/src/util.c
+++ b/src/util.c
@@ -101,7 +101,7 @@ static const char *const codes[1000] = {
   [530] = STATUS_CODE_530,
   [540] = STATUS_CODE_540,
   [561] = STATUS_CODE_561,
-  [590] = STATUS_CODE_598, STATUS_CODE_599,
+  [598] = STATUS_CODE_598, STATUS_CODE_599,
   [999] = NULL
 };
 

--- a/src/util.c
+++ b/src/util.c
@@ -859,7 +859,7 @@ char *
 ltrim (char *s) {
   char *begin = s;
 
-  while (isspace (*begin))
+  while (isspace ((unsigned char) *begin))
     ++begin;
   memmove (s, begin, strlen (begin) + 1);
 
@@ -874,7 +874,7 @@ char *
 rtrim (char *s) {
   char *end = s + strlen (s);
 
-  while ((end != s) && isspace (*(end - 1)))
+  while ((end != s) && isspace ((unsigned char) *(end - 1)))
     --end;
   *end = '\0';
 
@@ -1091,7 +1091,7 @@ strtoupper (char *str) {
     return str;
 
   while (*p != '\0') {
-    *p = toupper (*p);
+    *p = toupper ((unsigned char) *p);
     p++;
   }
 

--- a/src/util.c
+++ b/src/util.c
@@ -70,7 +70,7 @@ static const char *const code_type[] = {
 };
 
 /* HTTP status codes */
-static const char *const codes[1000] = {
+static const char *const codes[600] = {
   [0] = STATUS_CODE_0,
   [100] = STATUS_CODE_100, STATUS_CODE_101,
   [200] = STATUS_CODE_200, STATUS_CODE_201, STATUS_CODE_202, STATUS_CODE_203, STATUS_CODE_204,
@@ -102,7 +102,6 @@ static const char *const codes[1000] = {
   [540] = STATUS_CODE_540,
   [561] = STATUS_CODE_561,
   [598] = STATUS_CODE_598, STATUS_CODE_599,
-  [999] = NULL
 };
 
 /* Return part of a string
@@ -813,7 +812,7 @@ file_size (const char *filename) {
  * On success, the status code type/category is returned. */
 const char *
 verify_status_code_type (int code) {
-  if (code >= 0 && code <= 599 && code_type[code / 100] == NULL)
+  if (code < 0 || code > 599 || code_type[code / 100] == NULL)
     return "Unknown";
 
   return code_type[code / 100];
@@ -826,7 +825,7 @@ verify_status_code_type (int code) {
  * On success, the status code is returned. */
 const char *
 verify_status_code (int code) {
-  if (code >= 0 && code <= 599 && code_type[code / 100] == NULL && codes[code] == NULL)
+  if (code < 0 || code > 599 || code_type[code / 100] == NULL || codes[code] == NULL)
     return "Unknown";
 
   return codes[code];

--- a/src/util.c
+++ b/src/util.c
@@ -60,7 +60,7 @@
 pthread_mutex_t tz_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* HTTP status codes categories */
-static const char *code_type[] = {
+static const char *const code_type[] = {
   STATUS_CODE_0XX,
   STATUS_CODE_1XX,
   STATUS_CODE_2XX,
@@ -70,7 +70,7 @@ static const char *code_type[] = {
 };
 
 /* HTTP status codes */
-static const char *codes[1000] = {
+static const char *const codes[1000] = {
   [0] = STATUS_CODE_0,
   [100] = STATUS_CODE_100, STATUS_CODE_101,
   [200] = STATUS_CODE_200, STATUS_CODE_201, STATUS_CODE_202, STATUS_CODE_203, STATUS_CODE_204,
@@ -232,14 +232,14 @@ wc_match (const char *wc, char *str) {
  */
 static char *
 extract_hostname (const char *url) {
-  char *start, *end;
+  const char *start, *end;
   char *hostname = NULL;
 
   start = strstr (url, "://");
   if (start != NULL) {
     start += 3;
   } else {
-    start = (char *) url;
+    start = url;
   }
 
   end = strchr (start, '/');

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -57,6 +57,7 @@
 #include "error.h"
 #include "gslist.h"
 #include "sha1.h"
+#include "util.h"
 #include "xmalloc.h"
 
 /* *INDENT-OFF* */
@@ -348,24 +349,6 @@ escape_http_request (const char *src) {
   }
   *q = 0;
   return dest;
-}
-
-/* Make a string uppercase.
- *
- * On error the original string is returned.
- * On success, the uppercased string is returned. */
-static char *
-strtoupper (char *str) {
-  char *p = str;
-  if (str == NULL || *str == '\0')
-    return str;
-
-  while (*p != '\0') {
-    *p = toupper ((int) *p);
-    p++;
-  }
-
-  return str;
 }
 
 /* Chop n characters from the beginning of the supplied buffer.


### PR DESCRIPTION
* Constify read-only data
 
  Declare read-only data arrays const, to warn on accidental modification and let compilers place them in read-only memory sections.

* De-duplicate strtoupper()

  Avoid the duplicate definition of strtoupper() in websocket.c, just use the one from util.h.

* Avoid UB in character checking functions

  The functions classifying characters like isspace(3) require the input to be of type unsigned char or EOF.

* Avoid out-of-bounds access in serial processing mode

  When using just one job for processing the input lines do not use the out-of-bounds index 1 instead of the valid one 0.
  This currently seems to only work since the stack space of the in this case unused threads array is used.

* Insert the status code in the correct position

* Avoid out-of-bounds access for invalid HTTP status codes

  Avoid array access in case the status code is less than 0 or bigger than 599.

  Also reduce the size of the codes array.

* Avoid unnecessary string copies

  Do not duplicate the strings for enumeration keys, as they are read-only.