### PR TITLE
remove dup DotBot in browsers.list

### DIFF
--- a/config/browsers.list
+++ b/config/browsers.list
@@ -95,7 +95,6 @@ PetalBot								Crawlers
 Discordbot								Crawlers
 ZoominfoBot								Crawlers
 Googlebot								Crawlers
-DotBot									Crawlers
 AhrefsBot								Crawlers
 SemrushBot								Crawlers
 Adsbot									Crawlers


### PR DESCRIPTION
fixes `Duplicate browser entry: DotBot` error when this file is used with `browsers-file`