### PR TITLE
Adding docker-compose configuration files and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ terminal. Features include:
   Ability to build GoAccess' Docker image from upstream. You can still fully
   configure it, by using Volume mapping and editing `goaccess.conf`.  See
   [Docker](https://github.com/allinurl/goaccess#docker) section below.
+  There is also documentation how to use [docker-compose](./docker-compose/README.md).
 
 ### Nearly all web log formats... ###
 GoAccess allows any custom log format string. Predefined options include, but
@@ -214,6 +215,8 @@ A Docker image has been updated, capable of directing output from an access log.
 OR real-time
 
     tail -F access.log | docker run -p 7890:7890 --rm -i -e LANG=$LANG allinurl/goaccess -a -o report.html --log-format COMBINED --real-time-html -
+
+There is also documentation how to use [docker-compose](./docker-compose/README.md).
 
 ##### Build in isolated container
 

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,34 @@
+# Docker-compose configuration
+
+Here are two docker-compose configurations for goaccess which
+combine a static site with a real-time report of goaccess.
+The directories used are:
+
+- `configs` - for the nginx and goaccess configuration
+- `public` - the files served by nginx - put your static site here
+- `logs` - nginx logs - there is no log rotation in place!
+
+There are two flavors of the docker-compose files and the goaccess files: 
+- `*.vanilla.*` which need you to take care of the TLS certificates
+- `*.traefik.*` using traefik for TLS and domain routing
+
+## Vanilla
+
+For the vanilla version, you'll have to do the following:
+
+- put the TLS certificates into `configs/certs`, following the naming scheme
+in `goaccess.vanilla.conf`
+- route requests for the static webpage to port `8080`
+
+## Traefik
+
+The traefik version is setup to make it easier to do the routing.
+You don't need to take care of the TLS certificates, and the
+goaccess websocket gets its own subdomain.
+
+To put it all together, the following environment is needed:
+- traefik configured according to [Traefik-101](https://ineiti.ch/posts/traefik-101/traefik-101/)
+- DNS configuration for two domain names pointing to your server's IP:
+  - `yourdomain` for the static pages, e.g., a blog-post using [Hugo](https://gohugo.io/)
+  - `goaccess.yourdomain` for the stats with goaccess
+

--- a/docker-compose/configs/goaccess.traefik.conf
+++ b/docker-compose/configs/goaccess.traefik.conf
@@ -1,0 +1,9 @@
+tz Europe/Zurich
+time-format %H:%M:%S
+date-format %Y-%m-%d
+log-format COMBINED
+log-file /srv/logs/access.log
+output /srv/report/report.html
+real-time-html true
+ws-url wss://goaccess.yourdomain
+port 443

--- a/docker-compose/configs/goaccess.vanilla.conf
+++ b/docker-compose/configs/goaccess.vanilla.conf
@@ -1,0 +1,10 @@
+tz Europe/Zurich
+time-format %H:%M:%S
+date-format %Y-%m-%d
+log-format COMBINED
+log-file /srv/logs/access.log
+output /srv/report/report.html
+real-time-html true
+ws-url wss://yourdomain
+ssl-cert /srv/certs/yourdomain.crt
+ssl-key /srv/certs/yourdomain.key

--- a/docker-compose/configs/nginx.conf
+++ b/docker-compose/configs/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/docker-compose/docker-compose.traefik.yaml
+++ b/docker-compose/docker-compose.traefik.yaml
@@ -1,0 +1,33 @@
+services:
+  web:
+    image: nginx
+    volumes:
+      - ./logs:/var/log/nginx
+      - ./config/nginx.conf:/etc/nginx/nginx.conf
+      - ./public:/usr/share/nginx/html
+    labels:
+      - "traefik.enable=true"
+      - "fqdn=yourdomain"
+    networks:
+      - traefik
+
+  goaccess:
+    image: allinurl/goaccess
+    container_name: goaccess
+    volumes:
+      - ./configs/goaccess.traefik.conf:/srv/config/goaccess.conf
+      - ./logs:/srv/logs
+      - ./public:/srv/report
+    command: ["--no-global-config", "--config-file=/srv/config/goaccess.conf"]
+    labels:
+      - "traefik.enable=true"
+      - "fqdn=goaccess.yourdomain"
+      - "traefik.http.services.yourdomain-goaccess.loadbalancer.server.port=443"
+    restart: unless-stopped
+    networks:
+      - traefik
+
+networks:
+  traefik:
+    external:
+      name: traefik_traefik

--- a/docker-compose/docker-compose.vanilla.yaml
+++ b/docker-compose/docker-compose.vanilla.yaml
@@ -1,0 +1,21 @@
+services:
+  web:
+    image: nginx
+    ports:
+      - 8080:80
+    volumes:
+      - ./logs:/var/log/nginx
+      - ./config/nginx.conf:/etc/nginx/nginx.conf
+      - ./public:/usr/share/nginx/html
+
+  goaccess:
+    image: allinurl/goaccess
+    ports:
+      - 7890:7890
+    volumes:
+      - ./configs/goaccess.vanilla.conf:/srv/config/goaccess.conf
+      - ./logs:/srv/logs
+      - ./public:/srv/report
+      - ./configs/certs:/srv/certs
+    command: ["--no-global-config", "--config-file=/srv/config/goaccess.conf"]
+    restart: unless-stopped


### PR DESCRIPTION
This PR adds two flavors of docker-compose files for use of goaccess with a static webpage serve by nginx.
- `vanilla` where you'll have to do your own routing of the ports
- `traefik` using traefik for the configuration