### PR TITLE
Include stdint.h

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -47,6 +47,7 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
We use this, but it may not be included via other headers; fixes building on AIX.