### PR TITLE
Don't swap bytes on big endian platforms as a fallback

### DIFF
--- a/src/websocket.h
+++ b/src/websocket.h
@@ -88,6 +88,12 @@
 #  define be16toh(x) OSSwapBigToHostInt16(x)
 #  define be32toh(x) OSSwapBigToHostInt32(x)
 #  define be64toh(x) OSSwapBigToHostInt64(x)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#  define htobe16(x) (x)
+#  define htobe64(x) (x)
+#  define be16toh(x) (x)
+#  define be32toh(x) (x)
+#  define be64toh(x) (x)
 #else
 #  error Platform not supported!
 #endif


### PR DESCRIPTION
We're already on the network byte order, there's no need to swap bytes. For instance, AIX doesn't have a header for this, but it's already on a big endian platform, so it's unnecessary.