### PR TITLE
Fix bug related to `--4xx-to-unique-count` flag logic.

### DIFF
--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -1388,7 +1388,7 @@ static int
 include_uniq (GLogItem *logitem) {
   int u = conf.client_err_to_unique_count;
 
-  if (!logitem->status || (logitem->status / 100) != 4 || (u && (logitem->status / 100) == '4'))
+  if (!logitem->status || (logitem->status / 100) != 4 || (u && (logitem->status / 100) == 4))
     return 1;
   return 0;
 }


### PR DESCRIPTION
When I specified the flag `--4xx-to-unique-count` I expected to see non-zero visitors for 4xx requests in dashboard, but nothing changed.

Fixed bug with incorrectly checked 4xx status codes when `--4xx-to-unique-count` flag is specified.

The bug was introduced in commit 6d2cb7e.