### PR TITLE
Provide a hint about --invalid-requests whenever parser fails

### DIFF
--- a/src/labels.h
+++ b/src/labels.h
@@ -290,6 +290,8 @@
 /* Common UI Errors */
 #define ERR_FORMAT_HEADER              \
   _("Format Errors - Verify your log/date/time format")
+#define HINT_INVALID_REQUESTS          \
+  _("Use --invalid-requests option to store such lines in a file.")
 #define ERR_FORMAT_NO_DATE_FMT         \
   _("No date format was found on your conf file.")
 #define ERR_FORMAT_NO_LOG_FMT          \

--- a/src/parser.c
+++ b/src/parser.c
@@ -1645,6 +1645,7 @@ output_logerrors (void) {
   }
   fprintf (stderr, "==%d==\n", pid);
   fprintf (stderr, "==%d== %s\n", pid, ERR_FORMAT_HEADER);
+  fprintf (stderr, "==%d== %s\n", pid, HINT_INVALID_REQUESTS);
 }
 
 /* Ensure we have the following fields. */


### PR DESCRIPTION
Closes #2818

In https://github.com/allinurl/goaccess/issues/2818#issuecomment-2778983916 I was proposing also to change top line with the count as well (since there could be more than 10), but with all the i18n, decided not to overdo for this