### PR TITLE
ASN panel mention in goaccess.conf

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -510,6 +510,7 @@ double-decode false
 #enable-panel REMOTE_USER
 #enable-panel CACHE_STATUS
 #enable-panel GEO_LOCATION
+#enable-panel ASN
 #enable-panel MIME_TYPE
 #enable-panel TLS_TYPE
 
@@ -565,6 +566,7 @@ ignore-panel KEYPHRASES
 #ignore-panel REMOTE_USER
 #ignore-panel CACHE_STATUS
 #ignore-panel GEO_LOCATION
+#ignore-panel ASN
 #ignore-panel MIME_TYPE
 #ignore-panel TLS_TYPE
 


### PR DESCRIPTION
I got confused when i enabled the GEO_LOCATION panel to discover an "ASN Panel" that wasn't mentioned anywhere in the goaccess.conf parameters list.

This pull request updates the `config/goaccess.conf` file to include the ASN (Autonomous System Number) panel in both enabled and ignored panel configurations.

Changes to `config/goaccess.conf`:

* Added `#enable-panel ASN` to the list of enabled panels.
* Added `#ignore-panel ASN` to the list of ignored panels.