### PR TITLE
Use WebSocket HTTP server to serve HTML reports

### DIFF
--- a/src/gwsocket.c
+++ b/src/gwsocket.c
@@ -45,6 +45,7 @@
 #include "settings.h"
 #include "websocket.h"
 #include "wsauth.h"
+#include "util.h"
 #include "xmalloc.h"
 
 /* Allocate memory for a new GWSReader instance.
@@ -488,6 +489,7 @@ start_server (void *ptr_data) {
 /* Read and set the WebSocket config options. */
 static void
 set_ws_opts (void) {
+  const char *html_filename;
   ws_set_config_strict (1);
   if (conf.addr)
     ws_set_config_host (conf.addr);
@@ -505,6 +507,8 @@ set_ws_opts (void) {
     ws_set_config_sslcert (conf.sslcert);
   if (conf.sslkey)
     ws_set_config_sslkey (conf.sslkey);
+  if (find_output_type((char**)&html_filename, "html", 0) == 0)
+    ws_set_config_html_path(html_filename);
 #ifdef HAVE_LIBSSL
   if (conf.ws_auth_secret) {
     ws_set_config_auth_secret (conf.ws_auth_secret);

--- a/src/output.c
+++ b/src/output.c
@@ -1260,7 +1260,7 @@ print_json_defs (FILE *fp) {
   fprintf (fp, external_assets ? "\n" : "</script>");
 }
 
-static char *
+char *
 get_asset_filepath (const char *filename, const char *asset_fname) {
   char *fname = NULL, *path = NULL, *s = NULL;
 

--- a/src/output.h
+++ b/src/output.h
@@ -96,4 +96,5 @@ typedef struct GDefMetric_ {
 
 void output_html (GHolder * holder, const char *filename);
 
+char *get_asset_filepath (const char *filename, const char *asset_fname);
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -462,8 +462,11 @@ find_output_type (char **filename, const char *ext, int alloc) {
       return 0;
 
     if ((dot = strrchr (conf.output_formats[i], '.')) != NULL && strcmp (dot + 1, ext) == 0) {
-      if (alloc)
+      if (alloc && filename) {
         *filename = xstrdup (conf.output_formats[i]);
+      } else if (filename) {
+        *filename = conf.output_formats[i];
+      }
       return 0;
     }
   }

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -307,6 +307,14 @@ typedef struct WSServer_ {
   /* Connected Clients */
   GSLList *colist;
 
+  /* Cached Report Resources */
+  char *file_html;
+  off_t size_html;
+  char *file_css;
+  off_t size_css;
+  char *file_js;
+  off_t size_js;
+
 #ifdef HAVE_LIBSSL
   SSL_CTX *ctx;
 #endif

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -101,8 +101,10 @@
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #include "gslist.h"
 
+#define WS_OK_STR "HTTP/1.1 200 OK"
 #define WS_BAD_REQUEST_STR "HTTP/1.1 400 Invalid Request\r\n\r\n"
 #define WS_UNAUTHORIZED_STR "HTTP/1.1 401 Unauthorized\r\n\r\n"
+#define WS_NOT_FOUND_STR "HTTP/1.1 404 Not Found\n\r\n"
 #define WS_SWITCH_PROTO_STR "HTTP/1.1 101 Switching Protocols"
 #define WS_TOO_BUSY_STR "HTTP/1.1 503 Service Unavailable\r\n\r\n"
 
@@ -275,6 +277,7 @@ typedef struct WSConfig_ {
   const char *sslkey;
   const char *unix_socket;
   const char *auth_secret;
+  const char *html_path;
 
   /* Function pointer for JWT verification */
   int (*auth) (const char *jwt, const char *secret);
@@ -331,6 +334,7 @@ void ws_set_config_sslkey (const char *sslkey);
 void ws_set_config_strict (int strict);
 void ws_set_config_auth_secret (const char *auth_secret);
 void ws_set_config_auth_cb (int (*auth_cb) (const char *jwt, const char *secret));
+void ws_set_config_html_path (const char *html_path);
 void ws_start (WSServer * server);
 void ws_stop (WSServer * server);
 WSServer *ws_init (const char *host, const char *port, void (*initopts) (void));


### PR DESCRIPTION
See #2848 for the justification, but it should simplify the case of viewing the HTML reports when GoAccess is being run on another system.

On mind for this:

- The send code is somewhat unreliable; it will stop accepting new data for the buffers to send, truncating the output.
- ~~Doesn't handle static resources split out to other files yet (`--external-assets`)~~ Does so now.
- ~~It'd probably be more efficient to read the file once and then send it, since the report shouldn't change on disk until it's re-ran. It might help alleviate the issues with ~~ Doesn't seem to help this part - though it seems to truncate around ~32k, and small reports/the CSS are fine, larger reports, the JS are not.
- It may be better to make `find_output_type` not allocate at all and make callers do that.