### PR TITLE
Add OAI-SearchBot to Cralwers list

### DIFF
--- a/src/browsers.c
+++ b/src/browsers.c
@@ -234,6 +234,7 @@ static const char *const browsers[][2] = {
   {"Yahoo! Slurp", "Crawlers"},
   {"GoogleMobile", "Crawlers"},
   {"ZoteroTranslationServer", "Cralwers"},
+  {"OAI-SearchBot", "Cralwers"},
 
   /* Based on Firefox: place all Firefox-based browsers here */
   {"Camino", "Others"},


### PR DESCRIPTION
Other bots by OpenAI can be recognised by the heuristic match, so no need to add them.

Closes #2856