### PR TITLE
Fix Potential NULL dereference in ws_start when cfdstate remains uninitialized

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -2859,13 +2859,15 @@ ws_start (WSServer *server) {
   while (run) {
     /* take a copy of the fdstate and give that to poll to allow
      * any dispatch to modify the real fdstate for the next pass */
-    if (ncfdstate != nfdstate) {
-      free (cfdstate);
-      cfdstate = xmalloc (nfdstate * sizeof (*cfdstate));
-      memset (cfdstate, 0, sizeof (*cfdstate) * nfdstate);
-      ncfdstate = nfdstate;
+    if (nfdstate > 0 ) {
+	  if (ncfdstate != nfdstate) {
+      		free (cfdstate);
+      		cfdstate = xmalloc (nfdstate * sizeof (*cfdstate));
+      		memset (cfdstate, 0, sizeof (*cfdstate) * nfdstate);
+      		ncfdstate = nfdstate;
+    	  }	
+    	  memcpy (cfdstate, fdstate, ncfdstate * sizeof (*cfdstate));
     }
-    memcpy (cfdstate, fdstate, ncfdstate * sizeof (*cfdstate));
 
     /* yep, wait patiently */
     if ((ret = poll (cfdstate, nfdstate, -1)) == -1) {


### PR DESCRIPTION
### Describe

This PR fixes a potential `NULL` pointer dereference in the `ws_start()` function of the WebSocket server.

If the condition `ncfdstate != nfdstate` evaluates to false during the first loop iteration, the `cfdstate` buffer remains unallocated (`NULL`), but is still passed to `memcpy()`, leading to undefined behavior or a crash.

### Expected Behavior

- `cfdstate` should always be allocated before being passed to `memcpy()`.
- The logic should skip memory operations entirely if `nfdstate == 0`.

### Actual Behavior

- On the first iteration:
    - `cfdstate` is initialized as `NULL`.
    - If `ncfdstate == nfdstate`, allocation is skipped.
    - `memcpy()` is called with a `NULL` destination.

### How to Reproduce

1. Run `ws_start()` when no connections exist (i.e., `nfdstate == 0`).
2. Enter the first iteration of the main loop.
3. Observe a crash or undefined behavior when `memcpy()` is invoked.

This patch preserves the existing logic while ensuring memory safety.

Thanks for reviewing.