### PR TITLE
Include `--with-zlib` and `--enable-asan` in version info when configured

### DIFF
--- a/src/commons.c
+++ b/src/commons.c
@@ -172,6 +172,9 @@ display_version (void) {
 #ifdef DEBUG
   fprintf (stdout, "  --enable-debug\n");
 #endif
+#ifdef __SANITIZE_ADDRESS__
+  fprintf (stdout, "  --enable-asan\n");
+#endif
 #ifdef HAVE_NCURSESW_NCURSES_H
   fprintf (stdout, "  --enable-utf8\n");
 #endif

--- a/src/commons.c
+++ b/src/commons.c
@@ -187,6 +187,9 @@ display_version (void) {
 #ifdef HAVE_LIBSSL
   fprintf (stdout, "  --with-openssl\n");
 #endif
+#ifdef HAVE_ZLIB
+  fprintf (stdout, "  --with-zlib\n");
+#endif
 }
 
 /* Get the enumerated value given a string.


### PR DESCRIPTION
I did also check for other missing options, and these are the only two options documented at https://goaccess.io/man#configuration but not included in the output.