### PR TITLE
fix: add large file support defines to fileio.c and persistence.c

### DIFF
--- a/src/fileio.c
+++ b/src/fileio.c
@@ -29,6 +29,10 @@
  * SOFTWARE.
  */
 
+#define _LARGEFILE_SOURCE
+#define _LARGEFILE64_SOURCE
+#define _FILE_OFFSET_BITS 64
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/persistence.c
+++ b/src/persistence.c
@@ -28,6 +28,10 @@
  * SOFTWARE.
  */
 
+#define _LARGEFILE_SOURCE
+#define _LARGEFILE64_SOURCE
+#define _FILE_OFFSET_BITS 64
+
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
Without _FILE_OFFSET_BITS=64 and related LFS defines, fopen() and stat() fail with EOVERFLOW on 32-bit systems when opening log files larger than 2GB. Every other source file in the project already defines these macros.

The issue we had on 32 bit Debian Trixie:
Unable to open the specified log file '/var/log/nginx/access.log.1'. Value too large for defined data type