### PR TITLE
Add persisted database retention window

### DIFF
--- a/config/goaccess.conf
+++ b/config/goaccess.conf
@@ -593,6 +593,11 @@ ignore-panel KEYPHRASES
 #
 # keep-last 7
 
+# Retain only persisted storage entries newer than now minus the given number
+# of days when restoring. The suffix 'd' is optional.
+#
+# persist-retention 365d
+
 # Disable client IP validation. Useful if IP addresses have been
 # obfuscated before being logged.
 #

--- a/goaccess.1
+++ b/goaccess.1
@@ -945,6 +945,13 @@ status codes, use this option multiple times.
 \fB\-\-keep-last=<num_days>
 Keep the last specified number of days in storage. This will recycle the storage tables. e.g., keep & show only the last 7 days.
 .TP
+\fB\-\-persist-retention=<num_days[d]>
+Retain only persisted data newer than now minus the given number of days when
+restoring from disk. The optional
+.I d
+suffix may be used, e.g.,
+.I --persist-retention=365d.
+.TP
 \fB\-\-no-ip-validation
 Disable client IP validation. Useful if IP addresses have been obfuscated before
 being logged.

--- a/src/options.c
+++ b/src/options.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <ctype.h>
 #include <string.h>
 #include <getopt.h>
@@ -139,6 +140,7 @@ static const struct option long_opts[] = {
   {"origin"               , required_argument , 0 , 0  }  ,
   {"output-format"        , required_argument , 0 , 0  }  ,
   {"persist"              , no_argument       , 0 , 0  }  ,
+  {"persist-retention"    , required_argument , 0 , 0  }  ,
   {"pid-file"             , required_argument , 0 , 0  }  ,
   {"port"                 , required_argument , 0 , 0  }  ,
   {"process-and-exit"     , no_argument       , 0 , 0  }  ,
@@ -331,6 +333,8 @@ cmd_help (void)
   "  --num-tests=<number>            - Number of lines to test. >= 0 (10 default)\n"
   "  --persist                       - Persist data to disk on exit to the given\n"
   "                                    --db-path or to /tmp.\n"
+  "  --persist-retention=<NDAYS[d]>  - Retain only persisted data newer than\n"
+  "                                    now - NDAYS when restoring.\n"
   "  --process-and-exit              - Parse log and exit without outputting data.\n"
   "  --real-os                       - Display real OS names. e.g, Windows XP,\n"
   "                                    Snow Leopard.\n"
@@ -376,6 +380,29 @@ cmd_help (void)
   exit (EXIT_FAILURE);
 }
 /* *INDENT-ON* */
+
+static int
+parse_days_option (const char *oarg, uint32_t *out) {
+  char *sEnd = NULL;
+  unsigned long days = 0;
+
+  if (!oarg || *oarg == '-')
+    return 1;
+
+  errno = 0;
+  days = strtoul (oarg, &sEnd, 10);
+  if (oarg == sEnd || errno == ERANGE)
+    return 1;
+  if (*sEnd == 'd' || *sEnd == 'D')
+    sEnd++;
+  if (*sEnd != '\0')
+    return 1;
+  if (days > UINT32_MAX)
+    return 1;
+
+  *out = days;
+  return 0;
+}
 
 /* Push a command line option to the given array if within bounds and if it's
  * not in the array. */
@@ -771,6 +798,11 @@ parse_long_opt (const char *name, const char *oarg) {
   if (!strcmp ("persist", name))
     conf.persist = 1;
 
+  /* persisted database retention window */
+  if (!strcmp ("persist-retention", name) &&
+      parse_days_option (oarg, &conf.persist_retention) != 0)
+    FATAL ("Invalid --persist-retention option.");
+
   /* restore data from disk */
   if (!strcmp ("restore", name))
     conf.restore = 1;
@@ -957,11 +989,10 @@ parse_long_opt (const char *name, const char *oarg) {
 
   /* number of days to keep in storage */
   if (!strcmp ("keep-last", name)) {
-    char *sEnd;
-    int keeplast = strtol (oarg, &sEnd, 10);
-    if (oarg == sEnd || *sEnd != '\0' || errno == ERANGE)
+    uint32_t keeplast = 0;
+    if (parse_days_option (oarg, &keeplast) != 0)
       return;
-    conf.keep_last = keeplast >= 0 ? keeplast : 0;
+    conf.keep_last = keeplast;
   }
 
   /* refresh html every X seconds */

--- a/src/persistence.c
+++ b/src/persistence.c
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <time.h>
 #include <sys/stat.h>
 
 #include "persistence.h"
@@ -45,6 +46,61 @@
 
 static uint32_t *persisted_dates = NULL;
 static uint32_t persisted_dates_len = 0;
+
+static uint32_t
+normalize_date (uint32_t date) {
+  while (date > 99999999)
+    date /= 100;
+  return date;
+}
+
+static uint32_t
+get_retention_cutoff_date (void) {
+  char buf[DATE_LEN] = "";
+  time_t now = time (NULL);
+  struct tm tm;
+
+  if (!conf.persist_retention)
+    return 0;
+
+  if (!localtime_r (&now, &tm))
+    return 0;
+
+  tm.tm_mday -= conf.persist_retention;
+  tm.tm_isdst = -1;
+  if (mktime (&tm) == (time_t) -1)
+    return 0;
+
+  if (strftime (buf, sizeof buf, "%Y%m%d", &tm) <= 0)
+    return 0;
+
+  return str2int (buf);
+}
+
+static int
+should_retain_date (uint32_t date) {
+  static uint32_t retention_cutoff = 0;
+
+  if (conf.persist_retention && !retention_cutoff)
+    retention_cutoff = get_retention_cutoff_date ();
+
+  if (retention_cutoff && normalize_date (date) < retention_cutoff)
+    return 0;
+
+  return 1;
+}
+
+static void
+rebuild_retained_overall (void) {
+  GKDB *db = get_db_instance (DB_INSTANCE);
+  khash_t (si32) * overall = get_hdb (db, MTRC_CNT_OVERALL);
+
+  if (!conf.persist_retention || !overall)
+    return;
+
+  del_si32_free (overall, 1);
+  ins_si32 (overall, "total_requests", ht_sum_valid ());
+}
 
 /* Determine the path for the given database file.
  *
@@ -265,6 +321,9 @@ static int
 insert_restored_date (uint32_t date) {
   uint32_t i, len = 0;
 
+  if (!should_retain_date (date))
+    return 2;
+
   /* no keep last, simply insert the restored date to our storage */
   if (!conf.keep_last || persisted_dates_len < conf.keep_last)
     return ht_insert_date (date);
@@ -420,6 +479,8 @@ persist_si32 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -521,6 +582,8 @@ persist_is32 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -608,6 +671,8 @@ persist_ii32 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -636,6 +701,8 @@ persist_ii08 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -694,6 +761,8 @@ persist_u648 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -752,6 +821,8 @@ persist_iu64 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -811,6 +882,8 @@ persist_su64 (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, val, { tpl_pack (tn, 2); });
@@ -868,6 +941,8 @@ persist_igsl (GSMetric metric, const char *path, int module) {
 
   /* *INDENT-OFF* */
   HT_FOREACH_KEY (dates, date, {
+    if (!should_retain_date (date))
+      continue;
     if (!(hash = get_hash (module, date, metric)))
       return -1;
     kh_foreach (hash, key, node, {
@@ -1063,6 +1138,8 @@ persist_dates (void) {
   tn = tpl_map (fmt, &date);
   for (i = 0; i < len; ++i) {
     date = dates[i];
+    if (!should_retain_date (date))
+      continue;
     tpl_pack (tn, 1);
   }
   tpl_dump (tn, TPL_FILE, path);
@@ -1215,6 +1292,8 @@ restore_data (void) {
       restore_metric_type (module, module_metrics[i]);
     }
   }
+
+  rebuild_retained_overall ();
 
   if (migrated && !conf.persist)
     conf.persist = 1;

--- a/src/settings.h
+++ b/src/settings.h
@@ -199,6 +199,7 @@ typedef struct GConf_
   int skip_term_resolver;           /* no terminal resolver */
   int is_json_log_format;           /* is a json log format */
   uint32_t keep_last;               /* number of days to keep in storage */
+  uint32_t persist_retention;        /* number of days to retain from persisted storage */
   uint32_t num_tests;               /* number of lines to test */
   uint64_t html_refresh;            /* refresh html report every X of seconds */
   uint64_t log_size;                /* log size override */


### PR DESCRIPTION
Adds `--persist-retention=<days>[d]` to limit how much data is restored from a persisted database.

When GoAccess is run with `--restore --persist --persist-retention=365d`, it restores the existing persisted database but ignores date buckets older than the retention window. When the database is persisted again, only the retained date buckets are written back.

This is useful for large persisted databases where older aggregate data is no longer needed, but recent analytics should be preserved.

Example:

```bash
goaccess access.log --restore --persist --db-path /path/to/db --persist-retention=365d
```