### PR TITLE
minor fix: Updated man page to prevent .gz from being interpreted as a macro

### DIFF
--- a/goaccess.1
+++ b/goaccess.1
@@ -179,8 +179,8 @@ Build with zlib support for reading gzipped logs. Disabled by default.
 \fB\-\-with-openssl
 Compile GoAccess with OpenSSL support for its WebSocket server.
 \fB\-\-with-zlib
-Enables optional zlib support to allow parsing of compressed log files (e.g.,
-.gz) directly without manual decompression.
+Enables optional zlib support to allow parsing of compressed log files
+(e.g., .gz) directly without manual decompression.
 .SH OPTIONS
 .P
 The following options can be supplied to the command or specified in the


### PR DESCRIPTION
In the `--with-zlib` option description, the line wrapped such that `.gz` appeared at the start of a line, which causes its misinterpretation as a macro directive.  This fixes by reflowing the sentence.