### PR TITLE
Add QUERY to the list of http methods in gstorage.c

### DIFF
--- a/src/gstorage.c
+++ b/src/gstorage.c
@@ -154,6 +154,7 @@ const httpmethods http_methods[] = {
   { "CONNECT"          , 7  } ,
   { "PATCH"            , 5  } ,
   { "SEARCH"           , 6  } ,
+  { "QUERY"            , 5  } ,
   /* WebDav */
   { "PROPFIND"         , 8  } ,
   { "PROPPATCH"        , 9  } ,


### PR DESCRIPTION
RFC 10008[1] was published 15. June 2026, standardizing the use of HTTP QUERY as a way for safe, idempotent and cachable http calls.

Refs:
 - [1] https://www.rfc-editor.org/info/rfc10008