### PR TITLE
Use %zu printf format for type size_t

### DIFF
--- a/src/bin2c.c
+++ b/src/bin2c.c
@@ -116,7 +116,7 @@ main (int argc, char *argv[]) {
   ident = argv[3];
   need_comma = 0;
 
-  fprintf (f_output, "const char %s[%lu] = {", ident, file_size);
+  fprintf (f_output, "const char %s[%zu] = {", ident, file_size);
   for (i = 0; i < file_size; ++i) {
     if (buf[i] == '\0') {
       fprintf (stderr,
@@ -134,7 +134,7 @@ main (int argc, char *argv[]) {
     fprintf (f_output, "0x%.2x", buf[i] & 0xff);
   }
   fprintf (f_output, "\n};\n\n");
-  fprintf (f_output, "const int %s_length = %lu;\n", ident, file_size);
+  fprintf (f_output, "const int %s_length = %zu;\n", ident, file_size);
 
 #ifdef USE_BZ2
   fprintf (f_output, "const int %s_length_uncompressed = %u;\n", ident, uncompressed_size);


### PR DESCRIPTION
I am still using a 32-bit netbook, and even compiling stuff on it. Yes, I know it's outdated. While building goaccess, I got this GCC warning:

```
src/bin2c.c:119:39: warning: format ‘%lu’ expects argument of type ‘long unsigned int’,
but argument 4 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
  119 |   fprintf (f_output, "const char %s[%lu] = {", ident, file_size);
      |                                     ~~^               ~~~~~~~~~
      |                                       |               |
      |                                       |               size_t {aka unsigned int}
      |                                       long unsigned int
      |                                     %u
```

and the same warning on line 137.

This pull request fixes the printf format, which should be `%zu`.