### PR TITLE
Add ProxyAuth to the list of crawlers

### DIFF
--- a/config/browsers.list
+++ b/config/browsers.list
@@ -120,3 +120,4 @@ KrISS									Feeds
 SimplePie								Feeds
 Feedsubs								Feeds
 UniversalFeedParser							Feeds
+ProxyAuth								Crawlers


### PR DESCRIPTION
ProxyAuth can forward request authenticated user information through traditional reverse proxies such as Nginx, Caddy, etc., using the User-Agent header.

Example line logs in nginx: 
127.0.0.1 - - [22/Aug/2026:20:56:22 +0200] "GET /demo/oneui/login.html HTTP/1.1" 200 2963 "-" "ProxyAuth"

All my request is "Unknown" and no possible to monitor the request from ProxyAuth
<img width="611" height="187" alt="image" src="https://github.com/user-attachments/assets/7d13fb08-c7f2-46e1-ab15-e2da2fe764f8" />

Thank for your help!

Projet: https://proxyauth.app/
